### PR TITLE
fix: DatabasePath throws NotSupportedException for non-LiteDB stores (closes #26)

### DIFF
--- a/DataCore.Tests~/DataCoreStoreTests.cs
+++ b/DataCore.Tests~/DataCoreStoreTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AroAro.DataCore;
+using Xunit;
+
+namespace DataCore.Tests
+{
+    /// <summary>
+    /// Tests for DataCoreStore properties and error handling.
+    /// </summary>
+    public class DataCoreStoreTests
+    {
+        #region DatabasePath
+
+        [Fact]
+        public void DatabasePath_LiteDbStore_ReturnsNonNullPath()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                using var store = new DataCoreStore(Path.Combine(tempDir, "test.db"));
+                Assert.NotNull(store.DatabasePath);
+                Assert.Contains("test.db", store.DatabasePath);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void DatabasePath_NonLiteDbStore_ThrowsNotSupportedException()
+        {
+            using var store = new DataCoreStore(new FakeDataStore());
+            Assert.Throws<NotSupportedException>(() => store.DatabasePath);
+        }
+
+        #endregion
+
+        #region Mock IDataStore
+
+        /// <summary>
+        /// Minimal IDataStore implementation that is NOT LiteDbDataStore.
+        /// Used to test type-dependent behavior in DataCoreStore.
+        /// </summary>
+        private class FakeDataStore : IDataStore
+        {
+            public StorageBackend Backend => (StorageBackend)99;
+            public IReadOnlyCollection<string> DatasetNames => Array.Empty<string>();
+            public IReadOnlyCollection<string> TabularNames => Array.Empty<string>();
+            public IReadOnlyCollection<string> GraphNames => Array.Empty<string>();
+
+            public ITabularDataset CreateTabular(string name) => throw new NotImplementedException();
+            public ITabularDataset GetTabular(string name) => throw new NotImplementedException();
+            public ITabularDataset GetOrCreateTabular(string name) => throw new NotImplementedException();
+            public bool TryGetTabular(string name, out ITabularDataset tabular) { tabular = null; return false; }
+            public bool TabularExists(string name) => false;
+            public bool DeleteTabular(string name) => false;
+
+            public IGraphDataset CreateGraph(string name) => throw new NotImplementedException();
+            public IGraphDataset GetGraph(string name) => throw new NotImplementedException();
+            public IGraphDataset GetOrCreateGraph(string name) => throw new NotImplementedException();
+            public bool TryGetGraph(string name, out IGraphDataset graph) { graph = null; return false; }
+            public bool GraphExists(string name) => false;
+            public bool DeleteGraph(string name) => false;
+
+            public bool BeginTransaction() => true;
+            public bool Commit() => true;
+            public bool Rollback() => true;
+            public void ExecuteInTransaction(Action action) => action();
+            public T ExecuteInTransaction<T>(Func<T> action) => action();
+
+            public void Checkpoint() { }
+            public void ClearAll() { }
+            public void Dispose() { }
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/DataCoreStore.cs
+++ b/Runtime/DataCoreStore.cs
@@ -58,9 +58,19 @@ namespace AroAro.DataCore
         public IDataStore UnderlyingStore => _store;
 
         /// <summary>
-        /// 数据库路径
+        /// 数据库文件路径。仅在底层存储为 LiteDB 时可用。
         /// </summary>
-        public string DatabasePath => (_store as LiteDb.LiteDbDataStore)?.DatabasePath;
+        /// <exception cref="NotSupportedException">底层存储不支持路径查询时抛出</exception>
+        public string DatabasePath
+        {
+            get
+            {
+                if (_store is LiteDb.LiteDbDataStore liteDb)
+                    return liteDb.DatabasePath;
+                throw new NotSupportedException(
+                    $"DatabasePath is not supported for storage backend type '{_store.GetType().Name}'.");
+            }
+        }
 
         /// <summary>
         /// 所有数据集名称


### PR DESCRIPTION
## Problem
`DatabasePath` silently returned `null` via `as` cast when the underlying store was not `LiteDbDataStore`, risking downstream `NullReferenceException`.

## Fix
- Pattern match with `is` instead of `as` cast
- Throw `NotSupportedException` with clear message for unsupported backend types

## Tests
- `DatabasePath_LiteDbStore_ReturnsNonNullPath` — verifies LiteDB path works
- `DatabasePath_NonLiteDbStore_ThrowsNotSupportedException` — verifies non-LiteDB throws

**617 tests pass, 0 failures.**