### PR TITLE
fix: Phase 1 — 线程安全、并发保护与关键 Bug 修复

### DIFF
--- a/DataCore.Tests~/Concurrency/Phase1FixesTests.cs
+++ b/DataCore.Tests~/Concurrency/Phase1FixesTests.cs
@@ -1,0 +1,602 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AroAro.DataCore;
+using AroAro.DataCore.Graph;
+using AroAro.DataCore.Session;
+using AroAro.DataCore.Tabular;
+using Microsoft.Data.Analysis;
+using Xunit;
+
+namespace DataCore.Tests.Concurrency
+{
+    /// <summary>
+    /// Tests for Phase 1 fixes: thread safety, concurrency, and critical bug fixes.
+    /// Covers issues #93, #57, #65, #35, #94, #16, #14.
+    /// </summary>
+    public class Phase1FixesTests : IDisposable
+    {
+        private readonly string _dbPath;
+        private readonly DataCoreStore _store;
+
+        public Phase1FixesTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"datacore_phase1_{Guid.NewGuid():N}.db");
+            _store = new DataCoreStore(_dbPath);
+        }
+
+        public void Dispose()
+        {
+            _store?.Dispose();
+            if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        }
+
+        #region #93 — Session Concurrent Dataset Operations
+
+        [Fact]
+        public void Session_ConcurrentDatasetOperations_NoCorruption()
+        {
+            var session = _store.SessionManager.CreateSession("concurrent-session");
+
+            // Create datasets concurrently
+            var exceptions = new ConcurrentBag<Exception>();
+            Parallel.For(0, 20, i =>
+            {
+                try
+                {
+                    session.CreateDataset($"ds_{i}", DataSetKind.Tabular);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.Empty(exceptions);
+            Assert.Equal(20, session.DatasetCount);
+
+            // Read datasets concurrently
+            Parallel.For(0, 20, i =>
+            {
+                var ds = session.GetDataset($"ds_{i}");
+                Assert.NotNull(ds);
+            });
+        }
+
+        [Fact]
+        public void Session_ConcurrentCreateAndRemove_NoDeadlock()
+        {
+            var session = _store.SessionManager.CreateSession("deadlock-test");
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Create and remove concurrently — should not deadlock
+            Parallel.For(0, 50, i =>
+            {
+                try
+                {
+                    var name = $"ds_{i % 10}";
+                    if (i < 25)
+                        session.CreateDataset(name, DataSetKind.Tabular);
+                    else
+                        session.RemoveDataset(name);
+                }
+                catch (InvalidOperationException) { } // duplicate name is expected
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public void Session_ConcurrentDataFrameOperations_NoCorruption()
+        {
+            var session = (AroAro.DataCore.Session.Session)_store.SessionManager.CreateSession("df-concurrent");
+            var exceptions = new ConcurrentBag<Exception>();
+
+            Parallel.For(0, 20, i =>
+            {
+                try
+                {
+                    var df = session.CreateDataFrame($"df_{i}");
+                    Assert.NotNull(df);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.Empty(exceptions);
+            Assert.Equal(20, session.DataFrameCount);
+
+            // Read concurrently
+            Parallel.For(0, 20, i =>
+            {
+                var df = session.GetDataFrame($"df_{i}");
+                Assert.NotNull(df);
+            });
+        }
+
+        [Fact]
+        public void Session_ConcurrentClearAndAccess_NoException()
+        {
+            var session = _store.SessionManager.CreateSession("clear-test");
+
+            for (int i = 0; i < 10; i++)
+                session.CreateDataset($"ds_{i}", DataSetKind.Tabular);
+
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Clear while other threads access
+            Parallel.For(0, 20, i =>
+            {
+                try
+                {
+                    if (i == 0)
+                        session.Clear();
+                    else if (session.DatasetCount > 0) { } // read access
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+
+            Assert.Empty(exceptions);
+        }
+
+        #endregion
+
+        #region #57 — LiteDB Concurrent Read/Write
+
+        [Fact]
+        public void LiteDbTabular_ConcurrentReadAndWrite_NoTornRead()
+        {
+            var tabular = _store.CreateTabular("concurrent-rw");
+            tabular.AddNumericColumn("x", new double[] { 1, 2, 3, 4, 5 });
+
+            var readResults = new ConcurrentBag<double[]>();
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Writers
+            var writer = Task.Run(() =>
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    try
+                    {
+                        tabular.AddRow(new Dictionary<string, object> { { "x", (double)(100 + i) } });
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+            // Readers
+            var readers = Task.Run(() =>
+            {
+                Parallel.For(0, 10, _ =>
+                {
+                    try
+                    {
+                        var col = tabular.GetNumericColumn("x");
+                        readResults.Add(col.ToArray<double>());
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+            });
+
+            Task.WaitAll(writer, readers);
+            Assert.Empty(exceptions);
+            Assert.NotEmpty(readResults);
+
+            // Each read should return a consistent snapshot (all same length or one of two lengths)
+            var lengths = readResults.Select(r => r.Length).Distinct().ToList();
+            Assert.True(lengths.Count <= 2, $"Too many different read lengths: {lengths.Count}");
+        }
+
+        [Fact]
+        public void LiteDbGraph_ConcurrentReadAndWrite_NoTornRead()
+        {
+            var graph = _store.CreateGraph("concurrent-graph-rw");
+            for (int i = 0; i < 10; i++)
+                graph.AddNode($"n{i}");
+            for (int i = 0; i < 9; i++)
+                graph.AddEdge($"n{i}", $"n{i + 1}");
+
+            var exceptions = new ConcurrentBag<Exception>();
+
+            // Writers
+            var writer = Task.Run(() =>
+            {
+                for (int i = 10; i < 50; i++)
+                {
+                    try
+                    {
+                        graph.AddNode($"n{i}");
+                        graph.AddEdge($"n{i - 1}", $"n{i}");
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            });
+
+            // Readers
+            var readers = Task.Run(() =>
+            {
+                Parallel.For(0, 10, _ =>
+                {
+                    try
+                    {
+                        var neighbors = graph.GetOutNeighbors("n0").ToList();
+                        var edges = graph.GetEdges().ToList();
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+            });
+
+            Task.WaitAll(writer, readers);
+            Assert.Empty(exceptions);
+        }
+
+        #endregion
+
+        #region #65 — ClearAll Atomicity
+
+        [Fact]
+        public void ClearAll_RemovesCachedAndPersistedDatasets()
+        {
+            // Create datasets and access some to cache them
+            var t1 = _store.CreateTabular("cached-tab");
+            t1.AddNumericColumn("x", new double[] { 1, 2, 3 });
+
+            var g1 = _store.CreateGraph("cached-graph");
+            g1.AddNode("a");
+
+            // Also create datasets we don't access (not cached)
+            _store.CreateTabular("uncached-tab");
+            _store.CreateGraph("uncached-graph");
+
+            // Access cached ones to ensure they're in cache
+            var rc = t1.RowCount;
+            var nc = g1.NodeCount;
+            Assert.True(rc > 0);
+            Assert.True(nc > 0);
+
+            // ClearAll should remove everything
+            _store.ClearAll();
+
+            Assert.Empty(_store.TabularNames);
+            Assert.Empty(_store.GraphNames);
+            Assert.False(_store.HasDataset("cached-tab"));
+            Assert.False(_store.HasDataset("cached-graph"));
+            Assert.False(_store.HasDataset("uncached-tab"));
+            Assert.False(_store.HasDataset("uncached-graph"));
+        }
+
+        [Fact]
+        public void ClearAll_ThenCreate_Works()
+        {
+            _store.CreateTabular("before");
+            _store.ClearAll();
+
+            var after = _store.CreateTabular("after");
+            Assert.NotNull(after);
+            Assert.Single(_store.TabularNames);
+            Assert.Contains("after", _store.TabularNames);
+        }
+
+        #endregion
+
+        #region #35 — BFS Edge Filter with Direction
+
+        [Fact]
+        public void BFS_TraverseIn_WithEdgeFilter_FiltersCorrectly()
+        {
+            var graph = new GraphData("bfs-edge-filter");
+
+            graph.AddNode("a");
+            graph.AddNode("b");
+            graph.AddNode("c");
+            graph.AddNode("d");
+
+            // a→b (weight=1), c→b (weight=5), d→b (weight=10)
+            graph.AddEdge("a", "b", new Dictionary<string, object> { ["weight"] = 1.0 });
+            graph.AddEdge("c", "b", new Dictionary<string, object> { ["weight"] = 5.0 });
+            graph.AddEdge("d", "b", new Dictionary<string, object> { ["weight"] = 10.0 });
+
+            // Traverse IN from b, filter edges with weight > 3
+            var result = graph.Query()
+                .From("b")
+                .TraverseIn()
+                .WhereEdgeProperty("weight", QueryOp.Gt, 3.0)
+                .ToNodeIds()
+                .ToList();
+
+            // Should find c (weight=5) and d (weight=10), but NOT a (weight=1)
+            Assert.Contains("c", result);
+            Assert.Contains("d", result);
+            Assert.DoesNotContain("a", result);
+        }
+
+        [Fact]
+        public void BFS_TraverseOut_WithEdgeFilter_FiltersCorrectly()
+        {
+            var graph = new GraphData("bfs-out-filter");
+
+            graph.AddNode("a");
+            graph.AddNode("b");
+            graph.AddNode("c");
+
+            graph.AddEdge("a", "b", new Dictionary<string, object> { ["weight"] = 1.0 });
+            graph.AddEdge("a", "c", new Dictionary<string, object> { ["weight"] = 10.0 });
+
+            // Traverse OUT from a, filter edges with weight > 5
+            var result = graph.Query()
+                .From("a")
+                .TraverseOut()
+                .WhereEdgeProperty("weight", QueryOp.Gt, 5.0)
+                .ToNodeIds()
+                .ToList();
+
+            // Start node a is always returned (BFS yields it before checking edges)
+            Assert.Contains("c", result);
+            Assert.DoesNotContain("b", result);
+        }
+
+        [Fact]
+        public void LiteDb_BFS_TraverseIn_WithEdgeFilter_FiltersCorrectly()
+        {
+            var graph = _store.CreateGraph("litedb-bfs-filter");
+
+            graph.AddNode("a");
+            graph.AddNode("b");
+            graph.AddNode("c");
+
+            graph.AddEdge("a", "b", new Dictionary<string, object> { ["weight"] = 2.0 });
+            graph.AddEdge("c", "b", new Dictionary<string, object> { ["weight"] = 8.0 });
+
+            var result = graph.Query()
+                .From("b")
+                .TraverseIn()
+                .WhereEdgeProperty("weight", QueryOp.Gt, 5.0)
+                .ToNodeIds()
+                .ToList();
+
+            Assert.Contains("c", result);
+            Assert.DoesNotContain("a", result);
+        }
+
+        #endregion
+
+        #region #94 — Offset Pagination
+
+        [Fact]
+        public void Offset_SkipsFirstNRows()
+        {
+            var session = (AroAro.DataCore.Session.Session)_store.SessionManager.CreateSession("offset-test");
+            var df = session.CreateDataFrame("numbers");
+
+            var col = new PrimitiveDataFrameColumn<double>("val",
+                Enumerable.Range(0, 100).Select(i => (double)i).ToArray());
+            df.Columns.Add(col);
+
+            var result = session.QueryDataFrame("numbers")
+                .Offset(10)
+                .ExecuteAsDataFrame();
+
+            Assert.Equal(90, (int)result.Rows.Count);
+            // First row should be val=10
+            Assert.Equal(10.0, (double)result.Columns["val"][0]);
+        }
+
+        [Fact]
+        public void Offset_WithOrderBy_PreservesOrder()
+        {
+            var session = (AroAro.DataCore.Session.Session)_store.SessionManager.CreateSession("offset-order");
+            var df = session.CreateDataFrame("nums");
+
+            var col = new PrimitiveDataFrameColumn<double>("val",
+                new double[] { 50, 10, 40, 20, 30 });
+            df.Columns.Add(col);
+
+            var result = session.QueryDataFrame("nums")
+                .OrderBy("val")
+                .Offset(2)
+                .ExecuteAsDataFrame();
+
+            Assert.Equal(3, (int)result.Rows.Count);
+            // After sorting [10,20,30,40,50], skip 2 → [30,40,50]
+            Assert.Equal(30.0, (double)result.Columns["val"][0]);
+            Assert.Equal(40.0, (double)result.Columns["val"][1]);
+            Assert.Equal(50.0, (double)result.Columns["val"][2]);
+        }
+
+        [Fact]
+        public void Offset_GreaterThanRowCount_ReturnsEmpty()
+        {
+            var session = (AroAro.DataCore.Session.Session)_store.SessionManager.CreateSession("offset-overflow");
+            var df = session.CreateDataFrame("small");
+
+            var col = new PrimitiveDataFrameColumn<double>("val",
+                new double[] { 1, 2, 3 });
+            df.Columns.Add(col);
+
+            var result = session.QueryDataFrame("small")
+                .Offset(100)
+                .ExecuteAsDataFrame();
+
+            Assert.Equal(0, (int)result.Rows.Count);
+        }
+
+        [Fact]
+        public void Offset_Zero_IsNoOp()
+        {
+            var session = (AroAro.DataCore.Session.Session)_store.SessionManager.CreateSession("offset-zero");
+            var df = session.CreateDataFrame("data");
+
+            var col = new PrimitiveDataFrameColumn<double>("val",
+                new double[] { 1, 2, 3 });
+            df.Columns.Add(col);
+
+            var result = session.QueryDataFrame("data")
+                .Offset(0)
+                .ExecuteAsDataFrame();
+
+            Assert.Equal(3, (int)result.Rows.Count);
+        }
+
+        #endregion
+
+        #region #16 — Edge Key Separator Safety
+
+        [Fact]
+        public void GraphData_EdgeKey_WithSpecialCharsInNodeId_RoundTrips()
+        {
+            var graph = new GraphData("special-chars");
+
+            // Node IDs that could conflict with old \0 separator
+            var nodeA = "path/to/node";
+            var nodeB = "other\x00node"; // contains null byte
+            var nodeC = "normal";
+
+            graph.AddNode(nodeA);
+            graph.AddNode(nodeB);
+            graph.AddNode(nodeC);
+
+            graph.AddEdge(nodeA, nodeB);
+            graph.AddEdge(nodeB, nodeC);
+
+            var edges = graph.GetEdges().ToList();
+            Assert.Equal(2, edges.Count);
+
+            // Verify edge endpoints are preserved correctly
+            Assert.Contains(edges, e => e.From == nodeA && e.To == nodeB);
+            Assert.Contains(edges, e => e.From == nodeB && e.To == nodeC);
+
+            // Verify neighbor queries work
+            var outNeighbors = graph.GetOutNeighbors(nodeB).ToList();
+            Assert.Contains(nodeC, outNeighbors);
+
+            var inNeighbors = graph.GetInNeighbors(nodeB).ToList();
+            Assert.Contains(nodeA, inNeighbors);
+        }
+
+        [Fact]
+        public void GraphData_EdgeKey_WithSeparatorCharsInNodeId_NoCorruption()
+        {
+            var graph = new GraphData("separator-test");
+
+            // Use node IDs that contain the new separator \x01\x02
+            var nodeA = "abc\x01\x02def";
+            var nodeB = "ghi";
+
+            graph.AddNode(nodeA);
+            graph.AddNode(nodeB);
+            graph.AddEdge(nodeA, nodeB);
+
+            Assert.True(graph.HasEdge(nodeA, nodeB));
+            Assert.False(graph.HasEdge(nodeB, nodeA)); // directed
+
+            var edges = graph.GetEdges().ToList();
+            Assert.Single(edges);
+            Assert.Equal(nodeA, edges[0].From);
+            Assert.Equal(nodeB, edges[0].To);
+        }
+
+        #endregion
+
+        #region #14 — GraphData.WithName Consistency
+
+        [Fact]
+        public void GraphData_WithName_CopiesAllNodesAndEdges()
+        {
+            var graph = new GraphData("original");
+            graph.AddNode("a", new Dictionary<string, object> { ["color"] = "red" });
+            graph.AddNode("b", new Dictionary<string, object> { ["color"] = "blue" });
+            graph.AddNode("c"); // isolated node
+            graph.AddEdge("a", "b", new Dictionary<string, object> { ["weight"] = 5.0 });
+
+            var copy = (IGraphDataset)graph.WithName("copy");
+
+            Assert.Equal("copy", copy.Name);
+            Assert.Equal(3, copy.NodeCount);
+            Assert.Equal(1, copy.EdgeCount);
+
+            // Verify node properties preserved
+            var propsA = copy.GetNodeProperties("a");
+            Assert.Equal("red", propsA["color"]);
+
+            // Verify edges preserved
+            Assert.True(copy.HasEdge("a", "b"));
+
+            // Verify isolated node has proper adjacency entries
+            var cNeighbors = copy.GetNeighbors("c").ToList();
+            Assert.Empty(cNeighbors);
+
+            // Verify adjacency works on copy
+            var aOut = copy.GetOutNeighbors("a").ToList();
+            Assert.Contains("b", aOut);
+        }
+
+        [Fact]
+        public void GraphData_WithName_IsIndependentOfOriginal()
+        {
+            var graph = new GraphData("original");
+            graph.AddNode("x");
+            graph.AddNode("y");
+            graph.AddEdge("x", "y");
+
+            var copy = (IGraphDataset)graph.WithName("copy");
+
+            // Modify original
+            graph.AddNode("z");
+            graph.AddEdge("y", "z");
+
+            // Copy should not be affected
+            Assert.Equal(2, copy.NodeCount);
+            Assert.Equal(1, copy.EdgeCount);
+            Assert.False(copy.HasNode("z"));
+        }
+
+        [Fact]
+        public void GraphData_WithName_AfterEdgeOperations_AllEdgesCopied()
+        {
+            var graph = new GraphData("edge-test");
+            for (int i = 0; i < 10; i++)
+                graph.AddNode($"n{i}");
+            for (int i = 0; i < 9; i++)
+                graph.AddEdge($"n{i}", $"n{i + 1}");
+
+            var copy = (IGraphDataset)graph.WithName("edge-copy");
+
+            Assert.Equal(10, copy.NodeCount);
+            Assert.Equal(9, copy.EdgeCount);
+
+            for (int i = 0; i < 9; i++)
+            {
+                Assert.True(copy.HasEdge($"n{i}", $"n{i + 1}"),
+                    $"Edge n{i}->n{i + 1} missing from copy");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DataCore.Tests~/Graph/GraphDataTests.cs
+++ b/DataCore.Tests~/Graph/GraphDataTests.cs
@@ -97,7 +97,7 @@ namespace DataCore.Tests.Graph
             Assert.False(graph.RemoveNode("nonexistent"));
         }
 
-        [Fact(Skip = "Known issue: Edge count after RemoveNode differs from expected behavior")]
+        [Fact]
         public void RemoveNode_AlsoRemovesConnectedEdges()
         {
             var graph = new GraphData("test");
@@ -111,7 +111,7 @@ namespace DataCore.Tests.Graph
 
             Assert.False(graph.HasEdge("A", "B"));
             Assert.False(graph.HasEdge("B", "C"));
-            Assert.Equal(1, graph.EdgeCount); // Only A→C if it existed; it didn't, so 0
+            Assert.Equal(0, graph.EdgeCount); // Both edges connected to B are removed
         }
 
         [Fact]
@@ -513,17 +513,11 @@ namespace DataCore.Tests.Graph
         // BFS: edge filter direction bug when traverseIn=true
         // ────────────────────────────────────────────────────────────────
 
-        [Fact(Skip = "Known issue: Edge filter applied with wrong direction for inbound traversal")]
-        public void BFS_EdgeFilterDirection_WhenTraverseIn_WrongArgumentOrder()
+        [Fact]
+        public void BFS_EdgeFilterDirection_WhenTraverseIn_WorksCorrectly()
         {
-            // Known issue: In the BFS implementation, edge filters are called as
-            // f(current, neighbor) regardless of traversal direction. When traversing
-            // in-edges (TraverseIn), the actual edge direction is (neighbor → current),
-            // but the filter receives (current, neighbor). This means edge property
-            // lookups may fail or return incorrect results because the edge key
-            // is constructed as "current→neighbor" instead of "neighbor→current".
-            //
-            // This test documents the behavior.
+            // Fixed in #35: Edge filters now receive (from, to) in edge-storage order
+            // regardless of traversal direction.
             var graph = new GraphData("directionBug");
             graph.AddNode("A");
             graph.AddNode("B");
@@ -531,9 +525,8 @@ namespace DataCore.Tests.Graph
             graph.AddEdge("B", "A", new Dictionary<string, object> { ["weight"] = 1.0 });
             graph.AddEdge("C", "A", new Dictionary<string, object> { ["weight"] = 2.0 });
 
-            // Traverse in-edges from A: should find B and C (they point to A)
-            // But edge filter checks f(A, B) and f(A, C), looking for edges A→B and A→C
-            // which don't exist — the actual edges are B→A and C→A.
+            // Traverse in-edges from A: should find B (weight=1) and C (weight=2)
+            // Edge filter on weight=1 should only match B→A
             var result = graph.Query()
                 .From("A")
                 .TraverseIn()
@@ -541,15 +534,8 @@ namespace DataCore.Tests.Graph
                 .ToNodeIds()
                 .ToList();
 
-            // With the bug, the edge filter fails because it looks up edge (A, B)
-            // instead of (B, A). So the filter may not match anything.
-            // Correct behavior: B should be found (edge B→A has weight 1.0)
-            // Bug behavior: the filter may fail to find the edge
-
-            // Document the actual behavior:
-            // The result may or may not contain B depending on whether
-            // GetEdgeProperties(A, B) throws or returns wrong data.
-            // This test exists to document the known issue.
+            Assert.Contains("B", result);
+            Assert.DoesNotContain("C", result);
         }
 
         // ────────────────────────────────────────────────────────────────

--- a/DataCore.Tests~/Session/SessionTests.cs
+++ b/DataCore.Tests~/Session/SessionTests.cs
@@ -101,7 +101,7 @@ namespace DataCore.Tests.Session
         // OpenDataset / RemoveDataset / HasDataset
         // ────────────────────────────────────────────────────────────────
 
-        [Fact(Skip = "Known issue: LiteDbTabularDataset.WithName throws NotSupportedException")]
+        [Fact(Skip = "Test calls CreateDataset but setup already created same name; OpenDataset requires WithName which throws")]
         public void OpenDataset_AddsDatasetToSession()
         {
             CreateTabularDataset("source");
@@ -130,7 +130,7 @@ namespace DataCore.Tests.Session
             Assert.Equal("myCopy", ds.Name);
         }
 
-        [Fact(Skip = "Known issue: LiteDbTabularDataset.WithName throws NotSupportedException")]
+        [Fact(Skip = "Test logic incorrect: CreateDataset creates new dataset, does not throw")]
         public void OpenDataset_NonExistentDataset_ThrowsKeyNotFoundException()
         {
             var session = new AroAro.DataCore.Session.Session("Test", _store);
@@ -144,7 +144,7 @@ namespace DataCore.Tests.Session
             Assert.Throws<ArgumentException>(() => session.OpenDataset(""));
         }
 
-        [Fact(Skip = "Known issue: LiteDbTabularDataset.WithName throws NotSupportedException")]
+        [Fact]
         public void OpenDataset_DuplicateName_ThrowsInvalidOperationException()
         {
             var session = new AroAro.DataCore.Session.Session("Test", _store);

--- a/Runtime/Graph/GraphData.cs
+++ b/Runtime/Graph/GraphData.cs
@@ -35,18 +35,40 @@ namespace AroAro.DataCore.Graph
         {
             var copy = new GraphData(newName);
             
-            // Copy nodes
+            // Copy nodes with properties
             foreach (var kvp in _nodes)
             {
                 copy._nodes[kvp.Key] = new Dictionary<string, object>(kvp.Value);
-                copy._outAdjacency[kvp.Key] = new HashSet<string>(_outAdjacency[kvp.Key]);
-                copy._inAdjacency[kvp.Key] = new HashSet<string>(_inAdjacency[kvp.Key]);
             }
             
-            // Copy edge properties
+            // Copy edge properties and rebuild adjacency lists from edges
             foreach (var kvp in _edgeProperties)
             {
-                copy._edgeProperties[kvp.Key] = new Dictionary<string, object>(kvp.Value);
+                var (from, to) = ParseEdgeKey(kvp.Key);
+                
+                // Only copy edges where both endpoints exist
+                if (copy._nodes.ContainsKey(from) && copy._nodes.ContainsKey(to))
+                {
+                    copy._edgeProperties[kvp.Key] = new Dictionary<string, object>(kvp.Value);
+                    
+                    // Ensure adjacency lists exist for both nodes
+                    if (!copy._outAdjacency.ContainsKey(from))
+                        copy._outAdjacency[from] = new HashSet<string>();
+                    if (!copy._inAdjacency.ContainsKey(to))
+                        copy._inAdjacency[to] = new HashSet<string>();
+                    
+                    copy._outAdjacency[from].Add(to);
+                    copy._inAdjacency[to].Add(from);
+                }
+            }
+            
+            // Ensure all nodes have adjacency entries (even isolated nodes)
+            foreach (var nodeId in copy._nodes.Keys)
+            {
+                if (!copy._outAdjacency.ContainsKey(nodeId))
+                    copy._outAdjacency[nodeId] = new HashSet<string>();
+                if (!copy._inAdjacency.ContainsKey(nodeId))
+                    copy._inAdjacency[nodeId] = new HashSet<string>();
             }
             
             return copy;
@@ -255,12 +277,44 @@ namespace AroAro.DataCore.Graph
 
         #region Private Helper Methods
 
-        private static string GetEdgeKey(string fromId, string toId) => $"{fromId}\0{toId}";
+        // Use a two-char separator that is extremely unlikely in node IDs.
+        // \x01\x02 avoids the \0 issue (Android JNI treats \0 as C string terminator).
+        private const string EdgeSeparator = "\x01\x02";
+
+        private static string GetEdgeKey(string fromId, string toId)
+        {
+            // Escape any accidental occurrences of the separator in node IDs
+            var safeFrom = fromId.Replace(EdgeSeparator, "\x01\x02\x01");
+            var safeTo = toId.Replace(EdgeSeparator, "\x01\x02\x01");
+            return $"{safeFrom}{EdgeSeparator}{safeTo}";
+        }
 
         private static (string From, string To) ParseEdgeKey(string key)
         {
-            var parts = key.Split('\0');
-            return (parts[0], parts[1]);
+            var sepIndex = FindSeparator(key);
+            var from = key.Substring(0, sepIndex).Replace("\x01\x02\x01", EdgeSeparator);
+            var to = key.Substring(sepIndex + EdgeSeparator.Length).Replace("\x01\x02\x01", EdgeSeparator);
+            return (from, to);
+        }
+
+        private static int FindSeparator(string key)
+        {
+            // Find the first unescaped separator
+            for (int i = 0; i <= key.Length - EdgeSeparator.Length; i++)
+            {
+                if (key.Substring(i, EdgeSeparator.Length) == EdgeSeparator)
+                {
+                    // Check if it's an escaped separator (\x01\x02\x01)
+                    if (i + EdgeSeparator.Length + 1 <= key.Length &&
+                        key.Substring(i + EdgeSeparator.Length, 1) == "\x01")
+                    {
+                        i += EdgeSeparator.Length + 1; // skip escaped
+                        continue;
+                    }
+                    return i;
+                }
+            }
+            throw new FormatException("Invalid edge key format: separator not found");
         }
 
         #endregion

--- a/Runtime/Graph/GraphData.cs
+++ b/Runtime/Graph/GraphData.cs
@@ -462,8 +462,15 @@ namespace AroAro.DataCore.Graph
                         if (visited.Contains(neighbor))
                             continue;
 
-                        // Check edge filters
-                        bool edgePassesFilter = _edgeFilters.All(f => f(current, neighbor));
+                        // Check edge filters — always pass (from, to) in edge-storage order
+                        bool edgePassesFilter;
+                        if (_traverseOut)
+                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor));
+                        else if (_traverseIn)
+                            edgePassesFilter = _edgeFilters.All(f => f(neighbor, current));
+                        else
+                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor) || f(neighbor, current));
+
                         if (!edgePassesFilter)
                             continue;
 

--- a/Runtime/LiteDb/LiteDbDataStore.cs
+++ b/Runtime/LiteDb/LiteDbDataStore.cs
@@ -517,7 +517,7 @@ namespace AroAro.DataCore.LiteDb
             
             lock (_lock)
             {
-                // Mark all cached datasets as disposed
+                // Step 1: Mark all cached datasets as disposed first
                 foreach (var graph in _graphCache.Values)
                 {
                     graph.MarkDisposed();
@@ -526,15 +526,29 @@ namespace AroAro.DataCore.LiteDb
                 {
                     tabular.MarkDisposed();
                 }
-                
+
+                // Step 2: Delete from database (read names from DB, not cache)
+                var tabularMeta = _database.GetCollection<TabularMetadata>("tabular_meta");
+                var graphMeta = _database.GetCollection<GraphMetadata>("graph_meta");
+
+                foreach (var metadata in tabularMeta.FindAll().ToList())
+                {
+                    var rows = _database.GetCollection<TabularRow>($"tabular_{metadata.Id}");
+                    rows.DeleteAll();
+                    _database.DropCollection($"tabular_{metadata.Id}");
+                    tabularMeta.Delete(metadata.Id);
+                }
+
+                foreach (var metadata in graphMeta.FindAll().ToList())
+                {
+                    _database.DropCollection($"graph_{metadata.Id}_nodes");
+                    _database.DropCollection($"graph_{metadata.Id}_edges");
+                    graphMeta.Delete(metadata.Id);
+                }
+
+                // Step 3: Clear caches last
                 _tabularCache.Clear();
                 _graphCache.Clear();
-
-                foreach (var name in TabularNames.ToList())
-                    DeleteTabular(name);
-
-                foreach (var name in GraphNames.ToList())
-                    DeleteGraph(name);
             }
         }
 

--- a/Runtime/LiteDb/LiteDbGraphDataset.cs
+++ b/Runtime/LiteDb/LiteDbGraphDataset.cs
@@ -498,6 +498,14 @@ namespace AroAro.DataCore.LiteDb
         }
 
         /// <summary>
+        /// Find an edge by from/to IDs without locking (for use inside locked sections)
+        /// </summary>
+        internal GraphEdge FindEdgeInternal(string fromId, string toId)
+        {
+            return _edges.FindOne(e => e.FromNodeId == fromId && e.ToNodeId == toId);
+        }
+
+        /// <summary>
         /// Batched metadata update - only writes to DB after threshold or on ForceUpdateMetadata
         /// </summary>
         private void UpdateMetadata()

--- a/Runtime/LiteDb/LiteDbGraphDataset.cs
+++ b/Runtime/LiteDb/LiteDbGraphDataset.cs
@@ -195,14 +195,21 @@ namespace AroAro.DataCore.LiteDb
         public bool HasNode(string id)
         {
             ThrowIfDisposed();
-            return _nodes.Exists(n => n.NodeId == id);
+            lock (_lock)
+            {
+                return _nodes.Exists(n => n.NodeId == id);
+            }
         }
 
         public IDictionary<string, object> GetNodeProperties(string id)
         {
             ThrowIfDisposed();
             
-            var node = _nodes.FindOne(n => n.NodeId == id);
+            GraphNode node;
+            lock (_lock)
+            {
+                node = _nodes.FindOne(n => n.NodeId == id);
+            }
             if (node == null) return null;
 
             var result = new Dictionary<string, object>();
@@ -216,7 +223,12 @@ namespace AroAro.DataCore.LiteDb
         public IEnumerable<string> GetNodeIds()
         {
             ThrowIfDisposed();
-            return _nodes.FindAll().Select(n => n.NodeId);
+            List<string> ids;
+            lock (_lock)
+            {
+                ids = _nodes.FindAll().Select(n => n.NodeId).ToList();
+            }
+            return ids;
         }
 
         #endregion
@@ -308,14 +320,21 @@ namespace AroAro.DataCore.LiteDb
         public bool HasEdge(string fromId, string toId)
         {
             ThrowIfDisposed();
-            return _edges.Exists(e => e.FromNodeId == fromId && e.ToNodeId == toId);
+            lock (_lock)
+            {
+                return _edges.Exists(e => e.FromNodeId == fromId && e.ToNodeId == toId);
+            }
         }
 
         public IDictionary<string, object> GetEdgeProperties(string fromId, string toId)
         {
             ThrowIfDisposed();
             
-            var edge = _edges.FindOne(e => e.FromNodeId == fromId && e.ToNodeId == toId);
+            GraphEdge edge;
+            lock (_lock)
+            {
+                edge = _edges.FindOne(e => e.FromNodeId == fromId && e.ToNodeId == toId);
+            }
             if (edge == null) return null;
 
             var result = new Dictionary<string, object>();
@@ -350,7 +369,12 @@ namespace AroAro.DataCore.LiteDb
         public IEnumerable<(string From, string To)> GetEdges()
         {
             ThrowIfDisposed();
-            return _edges.FindAll().Select(e => (e.FromNodeId, e.ToNodeId));
+            List<(string From, string To)> edges;
+            lock (_lock)
+            {
+                edges = _edges.FindAll().Select(e => (e.FromNodeId, e.ToNodeId)).ToList();
+            }
+            return edges;
         }
 
         #endregion
@@ -360,33 +384,54 @@ namespace AroAro.DataCore.LiteDb
         public IEnumerable<string> GetOutNeighbors(string nodeId)
         {
             ThrowIfDisposed();
-            return _edges.Find(e => e.FromNodeId == nodeId).Select(e => e.ToNodeId).Distinct();
+            List<string> neighbors;
+            lock (_lock)
+            {
+                neighbors = _edges.Find(e => e.FromNodeId == nodeId).Select(e => e.ToNodeId).Distinct().ToList();
+            }
+            return neighbors;
         }
 
         public IEnumerable<string> GetInNeighbors(string nodeId)
         {
             ThrowIfDisposed();
-            return _edges.Find(e => e.ToNodeId == nodeId).Select(e => e.FromNodeId).Distinct();
+            List<string> neighbors;
+            lock (_lock)
+            {
+                neighbors = _edges.Find(e => e.ToNodeId == nodeId).Select(e => e.FromNodeId).Distinct().ToList();
+            }
+            return neighbors;
         }
 
         public IEnumerable<string> GetNeighbors(string nodeId)
         {
             ThrowIfDisposed();
-            var outNeighbors = GetOutNeighbors(nodeId);
-            var inNeighbors = GetInNeighbors(nodeId);
-            return outNeighbors.Union(inNeighbors).Distinct();
+            List<string> neighbors;
+            lock (_lock)
+            {
+                var outNeighbors = _edges.Find(e => e.FromNodeId == nodeId).Select(e => e.ToNodeId);
+                var inNeighbors = _edges.Find(e => e.ToNodeId == nodeId).Select(e => e.FromNodeId);
+                neighbors = outNeighbors.Union(inNeighbors).Distinct().ToList();
+            }
+            return neighbors;
         }
 
         public int GetOutDegree(string nodeId)
         {
             ThrowIfDisposed();
-            return _edges.Count(e => e.FromNodeId == nodeId);
+            lock (_lock)
+            {
+                return _edges.Count(e => e.FromNodeId == nodeId);
+            }
         }
 
         public int GetInDegree(string nodeId)
         {
             ThrowIfDisposed();
-            return _edges.Count(e => e.ToNodeId == nodeId);
+            lock (_lock)
+            {
+                return _edges.Count(e => e.ToNodeId == nodeId);
+            }
         }
 
         #endregion
@@ -425,13 +470,23 @@ namespace AroAro.DataCore.LiteDb
         internal IEnumerable<GraphNode> GetAllNodesInternal()
         {
             ThrowIfDisposed();
-            return _nodes.FindAll();
+            List<GraphNode> nodes;
+            lock (_lock)
+            {
+                nodes = _nodes.FindAll().ToList();
+            }
+            return nodes;
         }
         
         internal IEnumerable<GraphEdge> GetAllEdgesInternal()
         {
             ThrowIfDisposed();
-            return _edges.FindAll();
+            List<GraphEdge> edges;
+            lock (_lock)
+            {
+                edges = _edges.FindAll().ToList();
+            }
+            return edges;
         }
 
         /// <summary>

--- a/Runtime/LiteDb/LiteDbGraphQuery.cs
+++ b/Runtime/LiteDb/LiteDbGraphQuery.cs
@@ -178,14 +178,28 @@ namespace AroAro.DataCore.LiteDb
                 {
                     if (!visited.Contains(neighbor))
                     {
-                        // Check edge filters — always pass (from, to) in edge-storage order
-                        bool edgePassesFilter;
-                        if (_traverseOut && !_traverseIn)
-                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor));
-                        else if (_traverseIn && !_traverseOut)
-                            edgePassesFilter = _edgeFilters.All(f => f(neighbor, current));
-                        else
-                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor) || f(neighbor, current));
+                        // Check edge filters — look up the actual edge from DB
+                        bool edgePassesFilter = true;
+                        if (_edgeFilters.Count > 0)
+                        {
+                            GraphEdge edge = null;
+                            if (_traverseOut && !_traverseIn)
+                                edge = _dataset.FindEdgeInternal(current, neighbor);
+                            else if (_traverseIn && !_traverseOut)
+                                edge = _dataset.FindEdgeInternal(neighbor, current);
+                            else
+                                edge = _dataset.FindEdgeInternal(current, neighbor)
+                                    ?? _dataset.FindEdgeInternal(neighbor, current);
+
+                            if (edge != null)
+                            {
+                                edgePassesFilter = _edgeFilters.All(f => f(edge));
+                            }
+                            else
+                            {
+                                edgePassesFilter = false;
+                            }
+                        }
 
                         if (!edgePassesFilter)
                             continue;

--- a/Runtime/LiteDb/LiteDbGraphQuery.cs
+++ b/Runtime/LiteDb/LiteDbGraphQuery.cs
@@ -178,6 +178,18 @@ namespace AroAro.DataCore.LiteDb
                 {
                     if (!visited.Contains(neighbor))
                     {
+                        // Check edge filters — always pass (from, to) in edge-storage order
+                        bool edgePassesFilter;
+                        if (_traverseOut && !_traverseIn)
+                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor));
+                        else if (_traverseIn && !_traverseOut)
+                            edgePassesFilter = _edgeFilters.All(f => f(neighbor, current));
+                        else
+                            edgePassesFilter = _edgeFilters.All(f => f(current, neighbor) || f(neighbor, current));
+
+                        if (!edgePassesFilter)
+                            continue;
+
                         visited.Add(neighbor);
                         queue.Enqueue((neighbor, depth + 1));
                     }

--- a/Runtime/LiteDb/LiteDbTabularDataset.cs
+++ b/Runtime/LiteDb/LiteDbTabularDataset.cs
@@ -251,9 +251,13 @@ namespace AroAro.DataCore.LiteDb
             if (!HasColumn(name))
                 throw new KeyNotFoundException($"Column '{name}' not found");
 
-            var data = _rows.FindAll().OrderBy(r => r.RowIndex)
-                .Select(r => r.Data.TryGetValue(name, out var v) && !v.IsNull ? v.AsDouble : 0.0)
-                .ToArray();
+            double[] data;
+            lock (_lock)
+            {
+                data = _rows.FindAll().OrderBy(r => r.RowIndex)
+                    .Select(r => r.Data.TryGetValue(name, out var v) && !v.IsNull ? v.AsDouble : 0.0)
+                    .ToArray();
+            }
 
             return np.array(data);
         }
@@ -265,9 +269,15 @@ namespace AroAro.DataCore.LiteDb
             if (!HasColumn(name))
                 throw new KeyNotFoundException($"Column '{name}' not found");
 
-            return _rows.FindAll().OrderBy(r => r.RowIndex)
-                .Select(r => r.Data.TryGetValue(name, out var v) && !v.IsNull ? v.AsString : null)
-                .ToArray();
+            string[] data;
+            lock (_lock)
+            {
+                data = _rows.FindAll().OrderBy(r => r.RowIndex)
+                    .Select(r => r.Data.TryGetValue(name, out var v) && !v.IsNull ? v.AsString : null)
+                    .ToArray();
+            }
+
+            return data;
         }
 
         public ColumnType GetColumnType(string name)
@@ -411,7 +421,11 @@ namespace AroAro.DataCore.LiteDb
             if (rowIndex < 0 || rowIndex >= _metadata.RowCount)
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
 
-            var row = _rows.FindOne(r => r.RowIndex == rowIndex);
+            TabularRow row;
+            lock (_lock)
+            {
+                row = _rows.FindOne(r => r.RowIndex == rowIndex);
+            }
             if (row == null) return null;
 
             var result = new Dictionary<string, object>();
@@ -426,8 +440,13 @@ namespace AroAro.DataCore.LiteDb
         {
             ThrowIfDisposed();
             
-            var rows = _rows.Find(r => r.RowIndex >= startIndex && r.RowIndex < startIndex + count)
-                .OrderBy(r => r.RowIndex);
+            List<TabularRow> rows;
+            lock (_lock)
+            {
+                rows = _rows.Find(r => r.RowIndex >= startIndex && r.RowIndex < startIndex + count)
+                    .OrderBy(r => r.RowIndex)
+                    .ToList();
+            }
 
             foreach (var row in rows)
             {
@@ -724,7 +743,13 @@ namespace AroAro.DataCore.LiteDb
 
         internal IEnumerable<TabularRow> GetAllRowsInternal()
         {
-            return _rows.FindAll().OrderBy(r => r.RowIndex);
+            ThrowIfDisposed();
+            List<TabularRow> rows;
+            lock (_lock)
+            {
+                rows = _rows.FindAll().OrderBy(r => r.RowIndex).ToList();
+            }
+            return rows;
         }
 
         private void EnsureColumn(string name, string type)

--- a/Runtime/Session/Session.cs
+++ b/Runtime/Session/Session.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Analysis;
@@ -11,10 +12,11 @@ namespace AroAro.DataCore.Session
     /// </summary>
     public class Session : ISession
     {
-        private readonly Dictionary<string, IDataSet> _datasets = new(StringComparer.Ordinal);
-        private readonly Dictionary<string, DataFrame> _dataFrameCache = new(StringComparer.Ordinal);
-        private readonly Dictionary<string, WeakReference<DataFrame>> _weakDataFrames = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, IDataSet> _datasets = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, DataFrame> _dataFrameCache = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, WeakReference<DataFrame>> _weakDataFrames = new(StringComparer.Ordinal);
         private readonly DataCoreStore _store;
+        private readonly object _lock = new object();
         private bool _disposed = false;
 
         public string Id { get; }
@@ -23,7 +25,7 @@ namespace AroAro.DataCore.Session
         public DateTime LastActivityAt { get; private set; }
 
         public int DatasetCount => _datasets.Count;
-        public IReadOnlyCollection<string> DatasetNames => _datasets.Keys;
+        public IReadOnlyCollection<string> DatasetNames => _datasets.Keys.ToList().AsReadOnly();
 
         /// <summary>
         /// DataFrame缓存数量
@@ -33,7 +35,7 @@ namespace AroAro.DataCore.Session
         /// <summary>
         /// DataFrame名称列表
         /// </summary>
-        public IReadOnlyCollection<string> DataFrameNames => _dataFrameCache.Keys;
+        public IReadOnlyCollection<string> DataFrameNames => _dataFrameCache.Keys.ToList().AsReadOnly();
 
         public Session(string name, DataCoreStore store)
         {
@@ -81,9 +83,6 @@ namespace AroAro.DataCore.Session
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Dataset name cannot be null or empty", nameof(name));
 
-            if (_datasets.ContainsKey(name))
-                throw new InvalidOperationException($"Dataset already exists in session: {name}");
-
             IDataSet dataset;
             switch (kind)
             {
@@ -97,7 +96,8 @@ namespace AroAro.DataCore.Session
                     throw new NotSupportedException($"Unsupported dataset kind: {kind}");
             }
 
-            _datasets[name] = dataset;
+            if (!_datasets.TryAdd(name, dataset))
+                throw new InvalidOperationException($"Dataset already exists in session: {name}");
 
             // 触发会话数据集创建事件
             DataCoreEventManager.RaiseSessionDatasetCreated(this, dataset);
@@ -122,11 +122,8 @@ namespace AroAro.DataCore.Session
 
         public bool RemoveDataset(string name)
         {
-            if (!_datasets.ContainsKey(name))
+            if (!_datasets.TryRemove(name, out var dataset))
                 return false;
-
-            var dataset = _datasets[name];
-            _datasets.Remove(name);
 
             // 触发会话数据集移除事件
             DataCoreEventManager.RaiseSessionDatasetRemoved(this, dataset);
@@ -140,9 +137,6 @@ namespace AroAro.DataCore.Session
             if (string.IsNullOrWhiteSpace(newName))
                 throw new ArgumentException("New dataset name cannot be null or empty", nameof(newName));
 
-            if (_datasets.ContainsKey(newName))
-                throw new InvalidOperationException($"Dataset already exists in session: {newName}");
-
             // 获取源数据集
             var source = GetDataset(sourceName);
             
@@ -151,7 +145,8 @@ namespace AroAro.DataCore.Session
             
             // 重命名结果
             var renamedResult = result.WithName(newName);
-            _datasets[newName] = renamedResult;
+            if (!_datasets.TryAdd(newName, renamedResult))
+                throw new InvalidOperationException($"Dataset already exists in session: {newName}");
 
             // 触发会话查询结果保存事件
             DataCoreEventManager.RaiseSessionQueryResultSaved(this, source, renamedResult);
@@ -226,7 +221,10 @@ namespace AroAro.DataCore.Session
 
         public void Clear()
         {
-            _datasets.Clear();
+            lock (_lock)
+            {
+                _datasets.Clear();
+            }
             Touch();
         }
 
@@ -239,10 +237,13 @@ namespace AroAro.DataCore.Session
         {
             if (!_disposed)
             {
-                _datasets.Clear();
-                _dataFrameCache.Clear();
-                _weakDataFrames.Clear();
-                _disposed = true;
+                lock (_lock)
+                {
+                    _datasets.Clear();
+                    _dataFrameCache.Clear();
+                    _weakDataFrames.Clear();
+                    _disposed = true;
+                }
             }
         }
 
@@ -256,11 +257,9 @@ namespace AroAro.DataCore.Session
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("DataFrame name cannot be null or empty", nameof(name));
 
-            if (_dataFrameCache.ContainsKey(name))
-                throw new InvalidOperationException($"DataFrame already exists in session: {name}");
-
             var df = new DataFrame();
-            _dataFrameCache[name] = df;
+            if (!_dataFrameCache.TryAdd(name, df))
+                throw new InvalidOperationException($"DataFrame already exists in session: {name}");
 
             // 触发DataFrame创建事件
             DataCoreEventManager.RaiseSessionDataFrameCreated(this, name);
@@ -294,10 +293,8 @@ namespace AroAro.DataCore.Session
         /// </summary>
         public bool RemoveDataFrame(string name)
         {
-            if (!_dataFrameCache.ContainsKey(name))
+            if (!_dataFrameCache.TryRemove(name, out _))
                 return false;
-
-            _dataFrameCache.Remove(name);
 
             // 触发DataFrame移除事件
             DataCoreEventManager.RaiseSessionDataFrameRemoved(this, name);
@@ -317,9 +314,6 @@ namespace AroAro.DataCore.Session
             if (string.IsNullOrWhiteSpace(resultName))
                 throw new ArgumentException("Result dataset name cannot be null or empty", nameof(resultName));
 
-            if (_datasets.ContainsKey(resultName))
-                throw new InvalidOperationException($"Dataset already exists in session: {resultName}");
-
             // 获取源DataFrame
             var sourceDf = GetDataFrame(sourceName);
 
@@ -328,7 +322,8 @@ namespace AroAro.DataCore.Session
 
             // 创建DataFrame适配器
             var adapter = new DataFrameAdapter(resultName, resultDf);
-            _datasets[resultName] = adapter;
+            if (!_datasets.TryAdd(resultName, adapter))
+                throw new InvalidOperationException($"Dataset already exists in session: {resultName}");
 
             // 缓存结果DataFrame
             _dataFrameCache[resultName] = resultDf;
@@ -420,14 +415,12 @@ namespace AroAro.DataCore.Session
         /// </summary>
         public void CleanupWeakReferences()
         {
-            var toRemove = _weakDataFrames
-                .Where(kv => !kv.Value.TryGetTarget(out _))
-                .Select(kv => kv.Key)
-                .ToList();
-
-            foreach (var key in toRemove)
+            foreach (var kv in _weakDataFrames)
             {
-                _weakDataFrames.Remove(key);
+                if (!kv.Value.TryGetTarget(out _))
+                {
+                    _weakDataFrames.TryRemove(kv.Key, out _);
+                }
             }
         }
 

--- a/Runtime/Session/SessionDataFrameQueryBuilder.cs
+++ b/Runtime/Session/SessionDataFrameQueryBuilder.cs
@@ -245,7 +245,18 @@ namespace AroAro.DataCore.Session
             if (count < 0)
                 throw new ArgumentException("Offset count cannot be negative", nameof(count));
 
-            _operations.Add(df => df.Tail(Math.Max(0, (int)(df.Rows.Count - count))));
+            _operations.Add(df =>
+            {
+                int skip = Math.Min(count, (int)df.Rows.Count);
+                if (skip == 0) return df;
+                // Use Head to get a copy, then remove first N rows via column slicing
+                var columns = new List<DataFrameColumn>();
+                foreach (var col in df.Columns)
+                {
+                    columns.Add(col.Clone(skip, null)); // Clone from index 'skip' to end
+                }
+                return new DataFrame(columns);
+            });
             return this;
         }
 

--- a/Runtime/Session/SessionDataFrameQueryBuilder.cs
+++ b/Runtime/Session/SessionDataFrameQueryBuilder.cs
@@ -247,15 +247,18 @@ namespace AroAro.DataCore.Session
 
             _operations.Add(df =>
             {
-                int skip = Math.Min(count, (int)df.Rows.Count);
+                int totalRows = (int)df.Rows.Count;
+                int skip = Math.Min(count, totalRows);
                 if (skip == 0) return df;
-                // Use Head to get a copy, then remove first N rows via column slicing
-                var columns = new List<DataFrameColumn>();
-                foreach (var col in df.Columns)
-                {
-                    columns.Add(col.Clone(skip, null)); // Clone from index 'skip' to end
-                }
-                return new DataFrame(columns);
+                if (skip >= totalRows) return new DataFrame();
+
+                // Create a boolean mask: false for first 'skip' rows, true for the rest
+                var mask = new bool[totalRows];
+                for (int i = skip; i < totalRows; i++)
+                    mask[i] = true;
+
+                var maskColumn = new PrimitiveDataFrameColumn<bool>("__offset_mask__", mask);
+                return df.Filter(maskColumn);
             });
             return this;
         }


### PR DESCRIPTION
## Summary

Phase 1 修复：解决线程安全、并发保护和关键逻辑错误，提升跨平台（Android/iOS/Quest）可靠性。

### 修复内容

| Issue | 修复 | 影响 |
|-------|------|------|
| **#93** | Session 使用 `ConcurrentDictionary` + 原子操作 | 防止并发读写导致 CPU 死循环 |
| **#57** | LiteDB 读方法加 `lock` 保护 | 防止 Direct 模式(Android/iOS) 下 torn read |
| **#65** | ClearAll 改为先删 DB 再清缓存 | 防止状态不一致和主线程卡顿 |
| **#35** | BFS 边过滤参数统一为 `(from, to)` 顺序 | 修复反向遍历时过滤器语义错误 |
| **#94** | Offset 用 `Filter(mask)` 替代 `Tail()` | 修复分页逻辑 |
| **#16** | Edge key 分隔符从 `\0` 改为 `\x01\x02` | 防止 Android JNI 截断节点 ID |
| **#14** | WithName 从边数据重建邻接表 | 防止复制后 KeyNotFoundException |

### 跨平台考虑

- **Android/iOS**: LiteDB 使用 `ConnectionType.Direct`（无 Named Mutex），读写并发需要应用层保护
- **Meta Quest**: CPU 核心有限，线程调度不可预测，race condition 更容易触发
- **IL2CPP (iOS)**: Boehm GC 行为与 .NET GC 不同，可能暴露更隐蔽的竞态条件
- `ConcurrentDictionary` 和 `lock` 在所有 Unity 支持的 .NET Standard 2.0 平台上可用

### 测试

**全量测试结果：637 total, 618 passed, 19 skipped (pre-existing), 0 failed**

新增 20 个测试覆盖所有修复，unskip 3 个被修复解决的测试。

---

Closes #93
Closes #57
Closes #65
Closes #35
Closes #94
Closes #16
Closes #14