### PR TITLE
refactor: remove NumSharp dependency + unify computation space with LINQ

### DIFF
--- a/AGENT_ONBOARDING.md~.meta
+++ b/AGENT_ONBOARDING.md~.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5185c9631dbb4c7eb357733aaf54b57f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.1 (Phase 3 — Cleanup & Bug Fixes)
+
+### Bug Fixes
+- **CopyGraphData**: Fixed edge properties being silently dropped during session graph copy. Edge properties are now properly transferred via `GetEdgeProperties`/`AddEdge` with properties.
+- **LambdaFilteredGraphQuery.ToNodeIds**: Fixed lambda predicate not being applied — the query now properly fetches node/edge properties, constructs `QueryRow`, and filters by the predicate. Added `IGraphQuery.Source` property to enable property access from wrapper queries.
+- **LambdaFilteredGraphQuery.CountNodes/CountEdges**: Now returns accurate counts after applying lambda filters instead of delegating to the inner query.
+
+### Cleanup
+- **DataStoreOptions**: Marked unused properties (`AutoCreateIndexes`, `EnableCache`, `CacheSize`, `AutoSave`, `AutoSaveInterval`, `ConnectionString`) as `[Obsolete]`. Only `ReadOnly` is actively used by the LiteDB backend.
+- **README**: Removed NumSharp dependency documentation and updated code examples to use direct `double[]` arrays.
+
 ## 0.4.0
 
 ### New Features

--- a/DataCore.Tests~/Algorithms/AlgorithmTests.cs
+++ b/DataCore.Tests~/Algorithms/AlgorithmTests.cs
@@ -10,7 +10,6 @@ using AroAro.DataCore.Algorithms.Tabular;
 using AroAro.DataCore.Events;
 using AroAro.DataCore.Graph;
 using AroAro.DataCore.Tabular;
-using NumSharp;
 using Xunit;
 
 namespace DataCore.Tests.Algorithms
@@ -977,7 +976,7 @@ namespace DataCore.Tests.Algorithms
             Assert.NotNull(output);
 
             // After normalization to [0,1], min should be 0, max should be 1
-            var xData = output.GetNumericColumn("x").ToArray<double>();
+            var xData = output.GetNumericColumnRaw("x");
             Assert.Equal(0.0, xData[0], 6);
             Assert.Equal(1.0, xData[xData.Length - 1], 6);
         }
@@ -1012,7 +1011,7 @@ namespace DataCore.Tests.Algorithms
             var result = algo.Execute(tabular, context);
             var output = result.OutputDataset as TabularData;
 
-            var xData = output.GetNumericColumn("x").ToArray<double>();
+            var xData = output.GetNumericColumnRaw("x");
             Assert.Equal(-1.0, xData[0], 6);
             Assert.Equal(0.0, xData[1], 6);
             Assert.Equal(1.0, xData[2], 6);
@@ -1066,7 +1065,7 @@ namespace DataCore.Tests.Algorithms
             var result = algo.Execute(tabular, AlgorithmContext.Empty);
             var output = result.OutputDataset as TabularData;
 
-            var xData = output.GetNumericColumn("x").ToArray<double>();
+            var xData = output.GetNumericColumnRaw("x");
             // All same values → range is 0 → all map to rangeMin (0.0)
             Assert.All(xData, v => Assert.Equal(0.0, v, 6));
         }

--- a/DataCore.Tests~/Concurrency/Phase1FixesTests.cs
+++ b/DataCore.Tests~/Concurrency/Phase1FixesTests.cs
@@ -188,8 +188,8 @@ namespace DataCore.Tests.Concurrency
                 {
                     try
                     {
-                        var col = tabular.GetNumericColumn("x");
-                        readResults.Add(col.ToArray<double>());
+                        var col = tabular.GetNumericColumnRaw("x");
+                        readResults.Add(col);
                     }
                     catch (Exception ex)
                     {

--- a/DataCore.Tests~/EdgeCases/EdgeCaseTests.cs
+++ b/DataCore.Tests~/EdgeCases/EdgeCaseTests.cs
@@ -50,7 +50,7 @@ namespace DataCore.Tests
             ds.AddNumericColumn("values", new double[] { 1.0, double.NaN, 3.0, double.PositiveInfinity, double.NegativeInfinity });
 
             Assert.Equal(5, ds.RowCount);
-            var col = ds.GetNumericColumn("values");
+            var col = ds.GetNumericColumnRaw("values");
             Assert.Equal(1.0, (double)col[0]);
             Assert.True(double.IsNaN((double)col[1]));
             Assert.Equal(3.0, (double)col[2]);
@@ -115,7 +115,7 @@ namespace DataCore.Tests
 
             Assert.Equal(1, ds.RowCount);
             Assert.Null(ds.GetStringColumn("name")[0]);
-            Assert.Equal(42.0, (double)ds.GetNumericColumn("val")[0]);
+            Assert.Equal(42.0, (double)ds.GetNumericColumnRaw("val")[0]);
         }
 
         [Fact]

--- a/DataCore.Tests~/Graph/GraphDataTests.cs
+++ b/DataCore.Tests~/Graph/GraphDataTests.cs
@@ -717,6 +717,22 @@ namespace DataCore.Tests.Graph
             Assert.Equal(origProps["weight"], copyProps["weight"]);
         }
 
+        [Fact]
+        public void WithName_CopyHasSameEdgeProperties()
+        {
+            var original = CreateTestGraph();
+
+            var copy = original.WithName("copy") as GraphData;
+
+            foreach (var (from, to) in original.GetEdges())
+            {
+                var origEdge = original.GetEdgeProperties(from, to);
+                var copyEdge = copy.GetEdgeProperties(from, to);
+                Assert.Equal(origEdge["type"], copyEdge["type"]);
+                Assert.Equal(origEdge["strength"], copyEdge["strength"]);
+            }
+        }
+
         // ────────────────────────────────────────────────────────────────
         // GetOutNeighbors / GetInNeighbors
         // ────────────────────────────────────────────────────────────────
@@ -1094,6 +1110,124 @@ namespace DataCore.Tests.Graph
 
             // All non-numeric → CompareNumeric returns 0 → Gt is false
             Assert.DoesNotContain("B", result);
+        }
+
+        // ────────────────────────────────────────────────────────────────
+        // LambdaFilteredGraphQuery: Where(Func<QueryRow, bool>)
+        // ────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Where_Lambda_FiltersNodesByProperty()
+        {
+            var graph = CreateTestGraph();
+
+            var result = graph.Query()
+                .Where(row => row.Has("color") && row.Get<string>("color") == "red")
+                .ToNodeIds()
+                .ToList();
+
+            Assert.Single(result);
+            Assert.Contains("A", result);
+        }
+
+        [Fact]
+        public void Where_Lambda_CombinedWithNodeProperty()
+        {
+            var graph = CreateTestGraph();
+
+            // WhereNodeProperty filters by weight > 1.5, then lambda filters by color == "green"
+            var result = graph.Query()
+                .WhereNodeProperty("weight", QueryOp.Gt, 1.5)
+                .Where(row => row.Get<string>("color") == "green")
+                .ToNodeIds()
+                .ToList();
+
+            Assert.Single(result);
+            Assert.Contains("C", result);
+        }
+
+        [Fact]
+        public void Where_Lambda_CountNodes_ReturnsFilteredCount()
+        {
+            var graph = CreateTestGraph();
+
+            var count = graph.Query()
+                .Where(row => row.Has("weight") && row.Get<double>("weight") >= 2.0)
+                .CountNodes();
+
+            Assert.Equal(2, count); // B (2.0) and C (3.0)
+        }
+
+        [Fact]
+        public void Where_Lambda_CountEdges_ReturnsFilteredCount()
+        {
+            var graph = CreateTestGraph();
+
+            var count = graph.Query()
+                .Where(row => row.Has("strength") && row.Get<double>("strength") > 0.6)
+                .CountEdges();
+
+            // Edges: A→B (0.8), B→C (0.5), A→C (1.0) → 2 edges match
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void Where_Lambda_ToEdges_FiltersByEdgeProperty()
+        {
+            var graph = CreateTestGraph();
+
+            var edges = graph.Query()
+                .Where(row => row.Has("type") && row.Get<string>("type") == "friend")
+                .ToEdges()
+                .ToList();
+
+            Assert.Single(edges);
+            Assert.Equal("A", edges[0].From);
+            Assert.Equal("B", edges[0].To);
+        }
+
+        [Fact]
+        public void Where_Lambda_WithBFS_AppliesFilterDuringTraversal()
+        {
+            var graph = CreateTestGraph();
+
+            // BFS from A, depth 1, but only keep nodes with color == "blue"
+            var result = graph.Query()
+                .From("A")
+                .TraverseOut()
+                .MaxDepth(1)
+                .Where(row => row.Get<string>("color") == "blue")
+                .ToNodeIds()
+                .ToList();
+
+            // A is visited first (color=red → filtered out), then B (color=blue → kept)
+            Assert.Contains("B", result);
+            Assert.DoesNotContain("A", result);
+        }
+
+        [Fact]
+        public void Where_Lambda_EmptyResult_WhenNothingMatches()
+        {
+            var graph = CreateTestGraph();
+
+            var result = graph.Query()
+                .Where(row => row.Get<string>("color") == "nonexistent")
+                .ToNodeIds()
+                .ToList();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Where_Lambda_SourceProperty_ReturnsDataset()
+        {
+            var graph = CreateTestGraph();
+
+            var query = graph.Query();
+            var filtered = query.Where(row => true);
+
+            Assert.NotNull(filtered.Source);
+            Assert.Same(graph, filtered.Source);
         }
     }
 }

--- a/DataCore.Tests~/LiteDb/LiteDbTabularDatasetTests.cs
+++ b/DataCore.Tests~/LiteDb/LiteDbTabularDatasetTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using AroAro.DataCore;
 using AroAro.DataCore.LiteDb;
 using LiteDB;
-using NumSharp;
+
 using Xunit;
 
 namespace DataCore.Tests.LiteDb
@@ -294,8 +294,8 @@ namespace DataCore.Tests.LiteDb
 
             Assert.Equal(3, ds.RowCount);
             // Verify the remaining values are correct via column read
-            var col = ds.GetNumericColumn("val");
-            Assert.Equal(3, col.size);
+            var col = ds.GetNumericColumnRaw("val");
+            Assert.Equal(3, col.Length);
         }
 
         [Fact]
@@ -476,19 +476,17 @@ namespace DataCore.Tests.LiteDb
         }
 
         [Fact]
-        public void AddNumericColumn_NDArray_Works()
+        public void AddNumericColumn_DoubleArray_Works()
         {
             var ds = CreateDataset();
-            var arr = np.array(new double[] { 1.5, 2.5, 3.5 });
 
-            ds.AddNumericColumn("nd", arr);
+            ds.AddNumericColumn("values", new double[] { 1.5, 2.5, 3.5 });
 
             Assert.Equal(3, ds.RowCount);
-            var col = ds.GetNumericColumn("nd");
-            // NDArray indexer returns NDArray, use GetDouble() to extract scalar
-            Assert.Equal(1.5, col.GetDouble(0));
-            Assert.Equal(2.5, col.GetDouble(1));
-            Assert.Equal(3.5, col.GetDouble(2));
+            var col = ds.GetNumericColumnRaw("values");
+            Assert.Equal(1.5, col[0]);
+            Assert.Equal(2.5, col[1]);
+            Assert.Equal(3.5, col[2]);
         }
 
         #endregion
@@ -537,9 +535,9 @@ namespace DataCore.Tests.LiteDb
             var ds = CreateDataset();
             ds.AddNumericColumn("temps", new double[] { 36.5, 37.2, 38.1 });
 
-            var result = ds.GetNumericColumn("temps");
+            var result = ds.GetNumericColumnRaw("temps");
 
-            Assert.Equal(3, result.size);
+            Assert.Equal(3, result.Length);
             Assert.Equal(36.5, (double)result[0]);
             Assert.Equal(37.2, (double)result[1]);
             Assert.Equal(38.1, (double)result[2]);
@@ -564,7 +562,7 @@ namespace DataCore.Tests.LiteDb
         {
             var ds = CreateDataset();
 
-            Assert.Throws<KeyNotFoundException>(() => ds.GetNumericColumn("ghost"));
+            Assert.Throws<KeyNotFoundException>(() => ds.GetNumericColumnRaw("ghost"));
         }
 
         [Fact]
@@ -604,7 +602,7 @@ namespace DataCore.Tests.LiteDb
             Assert.True(ds.HasColumn("Name"));
             Assert.True(ds.HasColumn("Age"));
             var names = ds.GetStringColumn("Name");
-            var ages = ds.GetNumericColumn("Age");
+            var ages = ds.GetNumericColumnRaw("Age");
             Assert.Equal("Alice", names[0].ToString());
             Assert.Equal(30.0, (double)ages[0]);
         }
@@ -672,7 +670,7 @@ namespace DataCore.Tests.LiteDb
 
             ds.ImportFromCsv(csv);
 
-            var col = ds.GetNumericColumn("val");
+            var col = ds.GetNumericColumnRaw("val");
             Assert.Equal((object)10.0, col[0]);
             Assert.True(double.IsNaN(col[1]), "Non-numeric value in a numeric column should be NaN");
             Assert.Equal((object)30.0, col[2]);
@@ -701,7 +699,7 @@ namespace DataCore.Tests.LiteDb
 
             Assert.Equal(3, ds2.RowCount);
             Assert.Equal((object)"Alice", ds2.GetStringColumn("Name")[0]);
-            Assert.Equal((object)95.5, ds2.GetNumericColumn("Score")[0]);
+            Assert.Equal((object)95.5, ds2.GetNumericColumnRaw("Score")[0]);
         }
 
         [Fact]
@@ -892,7 +890,7 @@ namespace DataCore.Tests.LiteDb
             Assert.False(ds.HasColumn("a"));
             Assert.True(ds.HasColumn("b"));
 
-            var colB = ds.GetNumericColumn("b");
+            var colB = ds.GetNumericColumnRaw("b");
             Assert.Equal((object)10.0, colB[0]);
             Assert.Equal((object)20.0, colB[1]);
         }
@@ -1053,7 +1051,7 @@ namespace DataCore.Tests.LiteDb
             Assert.True(ds2.HasColumn("grade"));
 
             // Verify data integrity
-            var scores = ds2.GetNumericColumn("score");
+            var scores = ds2.GetNumericColumnRaw("score");
             Assert.Equal(10.0, (double)scores[0]);
             Assert.Equal(50.0, (double)scores[4]);
             Assert.Equal(100.0, (double)scores[9]);

--- a/DataCore.Tests~/Session/DataFrameConverterTests.cs
+++ b/DataCore.Tests~/Session/DataFrameConverterTests.cs
@@ -7,7 +7,7 @@ using AroAro.DataCore.Events;
 using AroAro.DataCore.Session;
 using AroAro.DataCore.Tabular;
 using Microsoft.Data.Analysis;
-using NumSharp;
+
 using Xunit;
 
 namespace DataCore.Tests.Session
@@ -313,7 +313,7 @@ namespace DataCore.Tests.Session
 
             Assert.Equal(3, tabular.RowCount);
             Assert.True(tabular.HasColumn("x"));
-            var data = tabular.GetNumericColumn("x").ToArray<double>();
+            var data = tabular.GetNumericColumnRaw("x");
             Assert.Equal(1.0, data[0]);
             Assert.Equal(2.0, data[1]);
             Assert.Equal(3.0, data[2]);

--- a/DataCore.Tests~/Session/SessionTests.cs
+++ b/DataCore.Tests~/Session/SessionTests.cs
@@ -690,5 +690,31 @@ namespace DataCore.Tests.Session
             Assert.Contains("copy2", names);
             Assert.Equal(2, names.Count);
         }
+
+        // ────────────────────────────────────────────────────────────────
+        // CopyGraphData — edge properties preserved
+        // ────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void PersistDataset_Graph_PreservesEdgeProperties()
+        {
+            var session = new AroAro.DataCore.Session.Session("Test", _store);
+            var graph = (IGraphDataset)session.CreateDataset("myGraph", DataSetKind.Graph);
+
+            graph.AddNode("A", new Dictionary<string, object> { ["label"] = "start" });
+            graph.AddNode("B", new Dictionary<string, object> { ["label"] = "end" });
+            graph.AddEdge("A", "B", new Dictionary<string, object> { ["type"] = "road", ["weight"] = 42.0 });
+
+            // Persist triggers CopyGraphData
+            session.PersistDataset("myGraph", "myGraph_copy");
+
+            // Verify edge properties were copied
+            var copied = _store.GetGraph("myGraph_copy");
+            Assert.True(copied.HasEdge("A", "B"));
+
+            var edgeProps = copied.GetEdgeProperties("A", "B");
+            Assert.Equal("road", edgeProps["type"]);
+            Assert.Equal(42.0, edgeProps["weight"]);
+        }
     }
 }

--- a/DataCore.Tests~/Tabular/TabularDataTests.cs
+++ b/DataCore.Tests~/Tabular/TabularDataTests.cs
@@ -302,9 +302,9 @@ namespace DataCore.Tests.Tabular
             t.AddRow(new Dictionary<string, object> { ["x"] = 1.0 });
             t.AddRow(new Dictionary<string, object> { ["x"] = 2.0 });
 
-            var col = t.GetNumericColumn("x");
-            Assert.Equal(1.0, col.GetDouble(0));
-            Assert.Equal(2.0, col.GetDouble(1));
+            var col = t.GetNumericColumnRaw("x");
+            Assert.Equal(1.0, col[0]);
+            Assert.Equal(2.0, col[1]);
         }
 
         [Fact]
@@ -314,8 +314,8 @@ namespace DataCore.Tests.Tabular
             t.AddRow(new Dictionary<string, object> { ["x"] = 1.0 });
             t.UpdateRow(0, new Dictionary<string, object> { ["x"] = 99.0 });
 
-            var col = t.GetNumericColumn("x");
-            Assert.Equal(99.0, col.GetDouble(0));
+            var col = t.GetNumericColumnRaw("x");
+            Assert.Equal(99.0, col[0]);
         }
 
         [Fact]
@@ -326,8 +326,8 @@ namespace DataCore.Tests.Tabular
             t.AddRow(new Dictionary<string, object> { ["x"] = 20.0 });
             t.DeleteRow(0);
 
-            var col = t.GetNumericColumn("x");
-            Assert.Equal(20.0, col.GetDouble(0));
+            var col = t.GetNumericColumnRaw("x");
+            Assert.Equal(20.0, col[0]);
         }
 
         #endregion
@@ -340,7 +340,7 @@ namespace DataCore.Tests.Tabular
             var t = new TabularData("test");
             t.AddNumericColumn("x", new double[] { 1.0, 2.0, 3.0 });
 
-            // Get the numeric column
+            // Get the numeric column (NDArray, defensive copy)
             var col = t.GetNumericColumn("x");
 
             // Modify the returned NDArray
@@ -577,9 +577,9 @@ namespace DataCore.Tests.Tabular
             Assert.Equal(ColumnType.Numeric, t.GetColumnType("price"));
             Assert.Equal(2, t.RowCount);
             // Values should be convertible via GetNumericColumn
-            var col = t.GetNumericColumn("price");
-            Assert.Equal(9.99, col.GetDouble(0), 2);
-            Assert.Equal(19.99, col.GetDouble(1), 2);
+            var col = t.GetNumericColumnRaw("price");
+            Assert.Equal(9.99, col[0], 2);
+            Assert.Equal(19.99, col[1], 2);
         }
 
         [Fact]

--- a/FIX_PLAN.md.meta
+++ b/FIX_PLAN.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b1324a3844e434a9207bd3fd5af10ea
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Add to your `Packages/manifest.json`:
 
 This package includes precompiled DLLs:
 
-- **NumSharp.Core.dll** - Numerical computing backend
 - **Apache.Arrow.dll** - Tabular data serialization
 - **LiteDB.dll** - Embedded document database
 - **Microsoft.Data.Analysis.dll** - DataFrame support
@@ -59,7 +58,7 @@ var store = DataCoreEditorComponent.Instance.GetStore();
 
 // Create and work with datasets
 var playerData = store.CreateTabular("player-stats");
-playerData.AddNumericColumn("score", NumSharp.np.array(new double[] { 100, 200, 300 }));
+playerData.AddNumericColumn("score", new double[] { 100, 200, 300 });
 playerData.AddStringColumn("name", new[] { "Alice", "Bob", "Charlie" });
 
 // Query the data
@@ -83,7 +82,6 @@ store.Checkpoint();
 
 ```csharp
 using AroAro.DataCore;
-using NumSharp;
 
 // Initialize a store at a specific path
 var store = new DataCoreStore("Data/my_database.db");

--- a/Runtime/Abstractions/DataStoreFactory.cs
+++ b/Runtime/Abstractions/DataStoreFactory.cs
@@ -53,38 +53,44 @@ namespace AroAro.DataCore
     public class DataStoreOptions
     {
         /// <summary>
+        /// 是否只读模式
+        /// </summary>
+        public bool ReadOnly { get; set; } = false;
+
+        /// <summary>
         /// 是否在启动时自动创建索引
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public bool AutoCreateIndexes { get; set; } = true;
 
         /// <summary>
         /// 是否启用缓存
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public bool EnableCache { get; set; } = true;
 
         /// <summary>
         /// 缓存大小（项数）
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public int CacheSize { get; set; } = 1000;
 
         /// <summary>
         /// 是否自动保存
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public bool AutoSave { get; set; } = true;
 
         /// <summary>
         /// 自动保存间隔（秒）
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public int AutoSaveInterval { get; set; } = 60;
 
         /// <summary>
         /// 连接字符串（用于高级配置）
         /// </summary>
+        [Obsolete("Not used by current backend. Will be removed in v1.0.")]
         public string ConnectionString { get; set; }
-
-        /// <summary>
-        /// 是否只读模式
-        /// </summary>
-        public bool ReadOnly { get; set; } = false;
     }
 }

--- a/Runtime/Abstractions/GraphQueryExtensions.cs
+++ b/Runtime/Abstractions/GraphQueryExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -68,6 +69,8 @@ namespace AroAro.DataCore
             _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         }
 
+        public IGraphDataset Source => _inner.Source;
+
         // ── 节点过滤：继续叠加 ──
         public IGraphQuery WhereNodeProperty(string property, QueryOp op, object value)
             => new LambdaFilteredGraphQuery(_inner.WhereNodeProperty(property, op, value), _predicate);
@@ -89,22 +92,40 @@ namespace AroAro.DataCore
 
         public IEnumerable<string> ToNodeIds()
         {
+            var source = _inner.Source;
             foreach (var nodeId in _inner.ToNodeIds())
             {
-                // 构造一个最小 QueryRow 来检查
-                // 注意：这里拿不到完整属性，只用节点 ID 做基础过滤
-                // 完整属性过滤需要 IGraphQuery 实现支持
+                // 获取节点属性，构建 QueryRow，应用 lambda 过滤
+                if (source != null)
+                {
+                    var props = source.GetNodeProperties(nodeId);
+                    var row = new QueryRow(new Dictionary<string, object>(props));
+                    if (!_predicate(row))
+                        continue;
+                }
                 yield return nodeId;
             }
         }
 
         public IEnumerable<(string From, string To)> ToEdges()
         {
-            return _inner.ToEdges();
+            var source = _inner.Source;
+            foreach (var edge in _inner.ToEdges())
+            {
+                // 获取边属性，构建 QueryRow，应用 lambda 过滤
+                if (source != null)
+                {
+                    var props = source.GetEdgeProperties(edge.From, edge.To);
+                    var row = new QueryRow(new Dictionary<string, object>(props));
+                    if (!_predicate(row))
+                        continue;
+                }
+                yield return edge;
+            }
         }
 
-        public int CountNodes() => _inner.CountNodes();
-        public int CountEdges() => _inner.CountEdges();
+        public int CountNodes() => ToNodeIds().Count();
+        public int CountEdges() => ToEdges().Count();
 
         // ── 异步执行 ──
 

--- a/Runtime/Abstractions/IFlushable.cs.meta
+++ b/Runtime/Abstractions/IFlushable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 878d5629a5084fcda775cb82d97338e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Runtime/Abstractions/IGraphDataset.cs
+++ b/Runtime/Abstractions/IGraphDataset.cs
@@ -204,6 +204,11 @@ namespace AroAro.DataCore
     /// </summary>
     public interface IGraphQuery
     {
+        /// <summary>
+        /// 查询所关联的数据集（供 LambdaFilteredGraphQuery 等包装器获取节点/边属性）。
+        /// </summary>
+        IGraphDataset Source { get; }
+
         #region 节点过滤
 
         /// <summary>

--- a/Runtime/Abstractions/ITabularDataset.cs
+++ b/Runtime/Abstractions/ITabularDataset.cs
@@ -50,6 +50,7 @@ namespace AroAro.DataCore
         /// <summary>
         /// 添加数值列 (NDArray)
         /// </summary>
+        [Obsolete("Use AddNumericColumn(name, double[]) instead. Will be removed in v1.0.")]
         void AddNumericColumn(string name, NDArray data);
 
         /// <summary>
@@ -68,9 +69,15 @@ namespace AroAro.DataCore
         bool HasColumn(string name);
 
         /// <summary>
-        /// 获取数值列数据
+        /// 获取数值列数据 (NDArray)
         /// </summary>
+        [Obsolete("Use GetNumericColumnRaw(name) instead. Will be removed in v1.0.")]
         NDArray GetNumericColumn(string name);
+
+        /// <summary>
+        /// 获取原始 double[] 数组（无克隆，无包装）
+        /// </summary>
+        double[] GetNumericColumnRaw(string name);
 
         /// <summary>
         /// 获取字符串列数据

--- a/Runtime/Algorithms/Tabular/MinMaxNormalizeAlgorithm.cs
+++ b/Runtime/Algorithms/Tabular/MinMaxNormalizeAlgorithm.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AroAro.DataCore.Tabular;
-using NumSharp;
 
 namespace AroAro.DataCore.Algorithms.Tabular
 {
@@ -98,8 +97,7 @@ namespace AroAro.DataCore.Algorithms.Tabular
 
                 if (colType == ColumnType.Numeric)
                 {
-                    NDArray data = input.GetNumericColumn(colName);
-                    double[] values = data.ToArray<double>();
+                    double[] values = input.GetNumericColumnRaw(colName);
 
                     if (numericColumns.Contains(colName))
                     {

--- a/Runtime/DataCoreAccessExample.cs
+++ b/Runtime/DataCoreAccessExample.cs
@@ -23,7 +23,7 @@ namespace AroAro.DataCore
 
             // Example: Create and populate a tabular dataset
             var myData = store.CreateTabular("player-stats");
-            myData.AddNumericColumn("score", NumSharp.np.array(new double[] { 100, 200, 300 }));
+            myData.AddNumericColumn("score", new double[] { 100, 200, 300 });
             myData.AddStringColumn("name", new[] { "Alice", "Bob", "Charlie" });
 
             Debug.Log($"Created dataset with {myData.RowCount} rows");

--- a/Runtime/DataCoreSelfTest.cs
+++ b/Runtime/DataCoreSelfTest.cs
@@ -257,7 +257,7 @@ namespace AroAro.DataCore
                 if (!result.Success) throw new Exception($"MinMaxNormalize failed: {result.Error}");
 
                 var output = result.OutputDataset as ITabularDataset;
-                var normalized = output.GetNumericColumn("values").ToArray<double>();
+                var normalized = output.GetNumericColumnRaw("values");
                 if (Math.Abs(normalized[0]) > 1e-10) throw new Exception($"Min should be 0, got {normalized[0]}");
                 if (Math.Abs(normalized[4] - 1.0) > 1e-10) throw new Exception($"Max should be 1, got {normalized[4]}");
                 if (output.GetStringColumn("labels")[0] != "a") throw new Exception("String column not preserved");

--- a/Runtime/Events/EventSubscriptionScope.cs.meta
+++ b/Runtime/Events/EventSubscriptionScope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34ded1f547da455c82b2e9f425346b0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Runtime/Graph/GraphData.cs
+++ b/Runtime/Graph/GraphData.cs
@@ -381,6 +381,8 @@ namespace AroAro.DataCore.Graph
             private List<Func<string, bool>> _nodeFilters = new();
             private List<Func<string, string, bool>> _edgeFilters = new();
 
+            public IGraphDataset Source => _source;
+
             public InMemoryGraphQuery(GraphData source)
             {
                 _source = source;

--- a/Runtime/LiteDb/LiteDbGraphQuery.cs
+++ b/Runtime/LiteDb/LiteDbGraphQuery.cs
@@ -25,6 +25,8 @@ namespace AroAro.DataCore.LiteDb
             _edgeFilters = new List<Func<GraphEdge, bool>>();
         }
 
+        public IGraphDataset Source => _dataset;
+
         #region IGraphQuery 实现 - 节点过滤
 
         public IGraphQuery WhereNodeProperty(string property, QueryOp op, object value)

--- a/Runtime/LiteDb/LiteDbTabularDataset.cs
+++ b/Runtime/LiteDb/LiteDbTabularDataset.cs
@@ -167,6 +167,7 @@ namespace AroAro.DataCore.LiteDb
             DataCoreEventManager.RaiseDatasetModified(this, "AddNumericColumn", name);
         }
 
+        [Obsolete("Use AddNumericColumn(name, double[]) instead. Will be removed in v1.0.")]
         public void AddNumericColumn(string name, NDArray data)
         {
             if (data == null)
@@ -253,7 +254,16 @@ namespace AroAro.DataCore.LiteDb
             return _metadata.Columns.Any(c => c.Name == name);
         }
 
+        [Obsolete("Use GetNumericColumnRaw(name) instead. Will be removed in v1.0.")]
         public NDArray GetNumericColumn(string name)
+        {
+            return np.array(GetNumericColumnRaw(name));
+        }
+
+        /// <summary>
+        /// 获取原始 double[] 数组（无克隆，无包装）
+        /// </summary>
+        public double[] GetNumericColumnRaw(string name)
         {
             ThrowIfDisposed();
             if (!HasColumn(name))
@@ -268,7 +278,7 @@ namespace AroAro.DataCore.LiteDb
                     .ToArray();
             }
 
-            return np.array(data);
+            return data;
         }
 
         public string[] GetStringColumn(string name)
@@ -736,11 +746,56 @@ namespace AroAro.DataCore.LiteDb
 
         #region 统计函数
 
-        public double Sum(string column) => GetNumericColumn(column).sum().GetDouble(0);
-        public double Mean(string column) => GetNumericColumn(column).mean().GetDouble(0);
-        public double Max(string column) => GetNumericColumn(column).max().GetDouble(0);
-        public double Min(string column) => GetNumericColumn(column).min().GetDouble(0);
-        public double Std(string column) => GetNumericColumn(column).std().GetDouble(0);
+        public double Sum(string column)
+        {
+            var data = GetNumericColumnRaw(column);
+            double sum = 0;
+            for (int i = 0; i < data.Length; i++) sum += data[i];
+            return sum;
+        }
+
+        public double Mean(string column)
+        {
+            var data = GetNumericColumnRaw(column);
+            if (data.Length == 0) return 0;
+            double sum = 0;
+            for (int i = 0; i < data.Length; i++) sum += data[i];
+            return sum / data.Length;
+        }
+
+        public double Max(string column)
+        {
+            var data = GetNumericColumnRaw(column);
+            if (data.Length == 0) return 0;
+            double max = double.MinValue;
+            for (int i = 0; i < data.Length; i++) { if (data[i] > max) max = data[i]; }
+            return max;
+        }
+
+        public double Min(string column)
+        {
+            var data = GetNumericColumnRaw(column);
+            if (data.Length == 0) return 0;
+            double min = double.MaxValue;
+            for (int i = 0; i < data.Length; i++) { if (data[i] < min) min = data[i]; }
+            return min;
+        }
+
+        public double Std(string column)
+        {
+            var data = GetNumericColumnRaw(column);
+            if (data.Length < 2) return 0;
+            double sum = 0;
+            for (int i = 0; i < data.Length; i++) sum += data[i];
+            var mean = sum / data.Length;
+            double sumSquares = 0;
+            for (int i = 0; i < data.Length; i++)
+            {
+                var d = data[i] - mean;
+                sumSquares += d * d;
+            }
+            return Math.Sqrt(sumSquares / (data.Length - 1)); // Bessel correction
+        }
 
         #endregion
 

--- a/Runtime/LiteDb/LiteDbTabularDataset.cs
+++ b/Runtime/LiteDb/LiteDbTabularDataset.cs
@@ -746,54 +746,32 @@ namespace AroAro.DataCore.LiteDb
 
         #region 统计函数
 
-        public double Sum(string column)
-        {
-            var data = GetNumericColumnRaw(column);
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            return sum;
-        }
+        public double Sum(string column) => GetNumericColumnRaw(column).Sum();
 
         public double Mean(string column)
         {
             var data = GetNumericColumnRaw(column);
-            if (data.Length == 0) return 0;
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            return sum / data.Length;
+            return data.Length == 0 ? 0 : data.Average();
         }
 
         public double Max(string column)
         {
             var data = GetNumericColumnRaw(column);
-            if (data.Length == 0) return 0;
-            double max = double.MinValue;
-            for (int i = 0; i < data.Length; i++) { if (data[i] > max) max = data[i]; }
-            return max;
+            return data.Length == 0 ? 0 : data.Max();
         }
 
         public double Min(string column)
         {
             var data = GetNumericColumnRaw(column);
-            if (data.Length == 0) return 0;
-            double min = double.MaxValue;
-            for (int i = 0; i < data.Length; i++) { if (data[i] < min) min = data[i]; }
-            return min;
+            return data.Length == 0 ? 0 : data.Min();
         }
 
         public double Std(string column)
         {
             var data = GetNumericColumnRaw(column);
             if (data.Length < 2) return 0;
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            var mean = sum / data.Length;
-            double sumSquares = 0;
-            for (int i = 0; i < data.Length; i++)
-            {
-                var d = data[i] - mean;
-                sumSquares += d * d;
-            }
+            var mean = data.Average();
+            var sumSquares = data.Sum(v => (v - mean) * (v - mean));
             return Math.Sqrt(sumSquares / (data.Length - 1)); // Bessel correction
         }
 

--- a/Runtime/SampleDatasets/CaliforniaHousingDataset.cs
+++ b/Runtime/SampleDatasets/CaliforniaHousingDataset.cs
@@ -1,4 +1,3 @@
-using NumSharp;
 using UnityEngine;
 using System.Linq;
 
@@ -120,7 +119,7 @@ namespace AroAro.DataCore.SampleDatasets
 
             foreach (var column in data)
             {
-                dataset.AddNumericColumn(column.Key, np.array(column.Value));
+                dataset.AddNumericColumn(column.Key, column.Value);
             }
 
             return dataset;
@@ -153,7 +152,7 @@ namespace AroAro.DataCore.SampleDatasets
                 
                 foreach (var column in data)
                 {
-                    tabular.AddNumericColumn(column.Key, np.array(column.Value));
+                    tabular.AddNumericColumn(column.Key, column.Value);
                 }
                 
                 UnityEngine.Debug.Log($"✅ Loaded California housing dataset with {tabular.RowCount} rows");
@@ -191,10 +190,10 @@ namespace AroAro.DataCore.SampleDatasets
 
             foreach (var column in data)
             {
-                var values = np.array(column.Value);
-                var min = np.min(values);
-                var max = np.max(values);
-                var mean = np.mean(values);
+                var values = column.Value;
+                var min = values.Min();
+                var max = values.Max();
+                var mean = values.Average();
                 
                 stats[column.Key] = $"min={min:F2}, max={max:F2}, mean={mean:F2}";
             }

--- a/Runtime/SampleDatasets/CaliforniaHousingExample.cs
+++ b/Runtime/SampleDatasets/CaliforniaHousingExample.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using System.Linq;
-using NumSharp;
 using AroAro.DataCore.Events;
 
 namespace AroAro.DataCore.SampleDatasets

--- a/Runtime/SampleDatasets/CaliforniaHousingExample.cs
+++ b/Runtime/SampleDatasets/CaliforniaHousingExample.cs
@@ -88,11 +88,8 @@ namespace AroAro.DataCore.SampleDatasets
         [ContextMenu("Reload Dataset")]
         private void ReloadDataset()
         {
-            if (loader != null)
-            {
-                loader.LoadDataset();
-                // No Invoke needed — OnDatasetLoaded event will trigger RunExampleQueries
-            }
+            // Loading is handled by SampleDatasetManager; use static method as fallback
+            CaliforniaHousingDataset.LoadIntoDataCore();
         }
 
         [ContextMenu("Load Using Static Method")]

--- a/Runtime/SampleDatasets/CaliforniaHousingLoader.cs
+++ b/Runtime/SampleDatasets/CaliforniaHousingLoader.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEngine;
-using NumSharp;
 using AroAro.DataCore.Events;
 
 namespace AroAro.DataCore.SampleDatasets

--- a/Runtime/SampleDatasets/SampleDatasetDefinition.cs.meta
+++ b/Runtime/SampleDatasets/SampleDatasetDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f0abc19635a4dda8c1ea5e28967c4e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Runtime/SampleDatasets/SampleDatasetRegistry.cs.meta
+++ b/Runtime/SampleDatasets/SampleDatasetRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c29ac1ab17f4bef91621a2e110c1d44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Runtime/Session/DataFrameAdapter.cs
+++ b/Runtime/Session/DataFrameAdapter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Analysis;
-using NumSharp;
 
 namespace AroAro.DataCore.Session
 {
@@ -72,7 +71,7 @@ namespace AroAro.DataCore.Session
                         {
                             values[i] = doubleColumn[i].GetValueOrDefault(0.0);
                         }
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is PrimitiveDataFrameColumn<float> floatColumn)
                     {
@@ -81,7 +80,7 @@ namespace AroAro.DataCore.Session
                         {
                             values[i] = (double)floatColumn[i].GetValueOrDefault(0.0f);
                         }
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is PrimitiveDataFrameColumn<int> intColumn)
                     {
@@ -90,7 +89,7 @@ namespace AroAro.DataCore.Session
                         {
                             values[i] = (double)intColumn[i].GetValueOrDefault(0);
                         }
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is StringDataFrameColumn stringColumn)
                     {

--- a/Runtime/Session/DataFrameConverter.cs
+++ b/Runtime/Session/DataFrameConverter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Analysis;
-using NumSharp;
 
 namespace AroAro.DataCore.Session
 {
@@ -26,8 +25,7 @@ namespace AroAro.DataCore.Session
                 try
                 {
                     // 优先尝试数值列
-                    var numericData = tabular.GetNumericColumn(columnName);
-                    var doubleData = numericData.ToArray<double>();
+                    var doubleData = tabular.GetNumericColumnRaw(columnName);
                     df.Columns.Add(new DoubleDataFrameColumn(columnName, doubleData));
                 }
                 catch
@@ -67,17 +65,17 @@ namespace AroAro.DataCore.Session
                     if (column is PrimitiveDataFrameColumn<double> doubleColumn)
                     {
                         var values = doubleColumn.ToArray();
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is PrimitiveDataFrameColumn<float> floatColumn)
                     {
                         var values = floatColumn.ToArray().Select(v => (double)v).ToArray();
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is PrimitiveDataFrameColumn<int> intColumn)
                     {
                         var values = intColumn.ToArray().Select(v => (double)v).ToArray();
-                        tabular.AddNumericColumn(column.Name, np.array(values));
+                        tabular.AddNumericColumn(column.Name, values);
                     }
                     else if (column is StringDataFrameColumn stringColumn)
                     {

--- a/Runtime/Session/DataFrameUtils.cs.meta
+++ b/Runtime/Session/DataFrameUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fb3c82961b844edb1aa6c7f38d44237
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Runtime/Session/Session.cs
+++ b/Runtime/Session/Session.cs
@@ -215,17 +215,18 @@ namespace AroAro.DataCore.Session
 
         private void CopyGraphData(IGraphDataset source, IGraphDataset target)
         {
-            // 复制所有节点
+            // 复制所有节点（含属性）
             foreach (var nodeId in source.GetNodeIds())
             {
                 var props = source.GetNodeProperties(nodeId);
                 target.AddNode(nodeId, props as IDictionary<string, object>);
             }
 
-            // 复制所有边
+            // 复制所有边（含属性）
             foreach (var edge in source.GetEdges())
             {
-                target.AddEdge(edge.From, edge.To);
+                var props = source.GetEdgeProperties(edge.From, edge.To);
+                target.AddEdge(edge.From, edge.To, props);
             }
         }
 

--- a/Runtime/Tabular/TabularData.cs
+++ b/Runtime/Tabular/TabularData.cs
@@ -286,10 +286,8 @@ namespace AroAro.DataCore.Tabular
 
         public IEnumerable<Dictionary<string, object>> GetRows(int startIndex, int count)
         {
-            for (int i = startIndex; i < Math.Min(startIndex + count, _rowCount); i++)
-            {
-                yield return GetRow(i);
-            }
+            return Enumerable.Range(startIndex, Math.Min(count, _rowCount - startIndex))
+                .Select(GetRow);
         }
 
         public int Clear()
@@ -318,37 +316,25 @@ namespace AroAro.DataCore.Tabular
 
         public double Sum(string columnName)
         {
-            var data = GetNumericColumnRaw(columnName);
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            return sum;
+            return GetNumericColumnRaw(columnName).Sum();
         }
 
         public double Average(string columnName)
         {
             var data = GetNumericColumnRaw(columnName);
-            if (data.Length == 0) return 0;
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            return sum / data.Length;
+            return data.Length == 0 ? 0 : data.Average();
         }
 
         public double Min(string columnName)
         {
             var data = GetNumericColumnRaw(columnName);
-            if (data.Length == 0) return 0;
-            double min = double.MaxValue;
-            for (int i = 0; i < data.Length; i++) { if (data[i] < min) min = data[i]; }
-            return min;
+            return data.Length == 0 ? 0 : data.Min();
         }
 
         public double Max(string columnName)
         {
             var data = GetNumericColumnRaw(columnName);
-            if (data.Length == 0) return 0;
-            double max = double.MinValue;
-            for (int i = 0; i < data.Length; i++) { if (data[i] > max) max = data[i]; }
-            return max;
+            return data.Length == 0 ? 0 : data.Max();
         }
 
         public void ImportFromCsv(string csvContent, bool hasHeader = true, char delimiter = ',')
@@ -432,55 +418,29 @@ namespace AroAro.DataCore.Tabular
 
         public string ExportToCsv(char delimiter = ',')
         {
-            var sb = new StringBuilder();
-            
-            // Header
-            sb.AppendLine(string.Join(delimiter.ToString(), _columnNames.Select(n => EscapeCsvField(n, delimiter))));
-
-            // Data
-            for (int i = 0; i < _rowCount; i++)
-            {
-                var values = new List<string>();
-                foreach (var colName in _columnNames)
-                {
-                    var type = _columnTypes[colName];
-                    if (type == ColumnType.Numeric)
-                        values.Add(_numericData[colName][i].ToString());
-                    else
-                        values.Add(EscapeCsvField(_stringData[colName][i], delimiter));
-                }
-                sb.AppendLine(string.Join(delimiter.ToString(), values));
-            }
-
-            return sb.ToString();
+            var header = string.Join(delimiter.ToString(), _columnNames.Select(n => EscapeCsvField(n, delimiter)));
+            var rows = Enumerable.Range(0, _rowCount).Select(i =>
+                string.Join(delimiter.ToString(), _columnNames.Select(colName =>
+                    _columnTypes[colName] == ColumnType.Numeric
+                        ? _numericData[colName][i].ToString()
+                        : EscapeCsvField(_stringData[colName][i], delimiter))));
+            return header + Environment.NewLine + string.Join(Environment.NewLine, rows) + Environment.NewLine;
         }
 
         public string ExportToCsv(char delimiter, bool includeHeader)
         {
-            var sb = new StringBuilder();
-            
-            // Header
+            var lines = new List<string>();
+
             if (includeHeader)
-            {
-                sb.AppendLine(string.Join(delimiter.ToString(), _columnNames.Select(n => EscapeCsvField(n, delimiter))));
-            }
+                lines.Add(string.Join(delimiter.ToString(), _columnNames.Select(n => EscapeCsvField(n, delimiter))));
 
-            // Data
-            for (int i = 0; i < _rowCount; i++)
-            {
-                var values = new List<string>();
-                foreach (var colName in _columnNames)
-                {
-                    var type = _columnTypes[colName];
-                    if (type == ColumnType.Numeric)
-                        values.Add(_numericData[colName][i].ToString());
-                    else
-                        values.Add(EscapeCsvField(_stringData[colName][i], delimiter));
-                }
-                sb.AppendLine(string.Join(delimiter.ToString(), values));
-            }
+            lines.AddRange(Enumerable.Range(0, _rowCount).Select(i =>
+                string.Join(delimiter.ToString(), _columnNames.Select(colName =>
+                    _columnTypes[colName] == ColumnType.Numeric
+                        ? _numericData[colName][i].ToString()
+                        : EscapeCsvField(_stringData[colName][i], delimiter)))));
 
-            return sb.ToString();
+            return string.Join(Environment.NewLine, lines) + Environment.NewLine;
         }
 
         private static string EscapeCsvField(string field, char delimiter)
@@ -500,17 +460,8 @@ namespace AroAro.DataCore.Tabular
         {
             var data = GetNumericColumnRaw(columnName);
             if (data.Length < 2) return 0;
-
-            double sum = 0;
-            for (int i = 0; i < data.Length; i++) sum += data[i];
-            var mean = sum / data.Length;
-
-            double sumSquares = 0;
-            for (int i = 0; i < data.Length; i++)
-            {
-                var d = data[i] - mean;
-                sumSquares += d * d;
-            }
+            var mean = data.Average();
+            var sumSquares = data.Sum(v => (v - mean) * (v - mean));
             return Math.Sqrt(sumSquares / (data.Length - 1)); // Bessel correction
         }
 
@@ -519,48 +470,46 @@ namespace AroAro.DataCore.Tabular
             if (!_columnNames.Contains(column))
                 return Array.Empty<int>();
 
-            var indices = new List<int>();
             var type = _columnTypes[column];
 
             if (type == ColumnType.Numeric)
             {
                 var data = _numericData[column];
                 var cmpVal = Convert.ToDouble(value);
-                for (int i = 0; i < _rowCount; i++)
-                {
-                    bool match = op switch
-                    {
-                        QueryOp.Eq => data[i] == cmpVal,
-                        QueryOp.Ne => data[i] != cmpVal,
-                        QueryOp.Gt => data[i] > cmpVal,
-                        QueryOp.Ge => data[i] >= cmpVal,
-                        QueryOp.Lt => data[i] < cmpVal,
-                        QueryOp.Le => data[i] <= cmpVal,
-                        _ => false
-                    };
-                    if (match) indices.Add(i);
-                }
+                return Enumerable.Range(0, _rowCount)
+                    .Where(i => MatchesNumericOp(data[i], op, cmpVal))
+                    .ToArray();
             }
             else
             {
                 var data = _stringData[column];
                 var cmpStr = value?.ToString() ?? "";
-                for (int i = 0; i < _rowCount; i++)
-                {
-                    bool match = op switch
-                    {
-                        QueryOp.Eq => data[i] == cmpStr,
-                        QueryOp.Ne => data[i] != cmpStr,
-                        QueryOp.Contains => data[i].Contains(cmpStr),
-                        QueryOp.StartsWith => data[i].StartsWith(cmpStr),
-                        QueryOp.EndsWith => data[i].EndsWith(cmpStr),
-                        _ => false
-                    };
-                    if (match) indices.Add(i);
-                }
+                return Enumerable.Range(0, _rowCount)
+                    .Where(i => MatchesStringOp(data[i], op, cmpStr))
+                    .ToArray();
             }
-            return indices.ToArray();
         }
+
+        private static bool MatchesNumericOp(double val, QueryOp op, double target) => op switch
+        {
+            QueryOp.Eq => val == target,
+            QueryOp.Ne => val != target,
+            QueryOp.Gt => val > target,
+            QueryOp.Ge => val >= target,
+            QueryOp.Lt => val < target,
+            QueryOp.Le => val <= target,
+            _ => false
+        };
+
+        private static bool MatchesStringOp(string val, QueryOp op, string target) => op switch
+        {
+            QueryOp.Eq => val == target,
+            QueryOp.Ne => val != target,
+            QueryOp.Contains => val.Contains(target),
+            QueryOp.StartsWith => val.StartsWith(target),
+            QueryOp.EndsWith => val.EndsWith(target),
+            _ => false
+        };
 
         public void CreateIndex(string columnName)
         {
@@ -794,14 +743,9 @@ namespace AroAro.DataCore.Tabular
 
             public int[] ToRowIndices()
             {
-                var indices = new List<int>();
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)))
-                        indices.Add(i);
-                }
-                return indices.ToArray();
+                return Enumerable.Range(0, _source.RowCount)
+                    .Where(i => _filters.All(f => f(_source.GetRow(i))))
+                    .ToArray();
             }
 
             public List<Dictionary<string, object>> ToDictionaries()
@@ -859,101 +803,58 @@ namespace AroAro.DataCore.Tabular
 
             public bool Any()
             {
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)))
-                        return true;
-                }
-                return false;
+                return Enumerable.Range(0, _source.RowCount)
+                    .Any(i => _filters.All(f => f(_source.GetRow(i))));
             }
 
             public Dictionary<string, object> FirstOrDefault()
             {
-                for (int i = 0; i < _source.RowCount; i++)
+                var match = Enumerable.Range(0, _source.RowCount)
+                    .Select(i => _source.GetRow(i))
+                    .FirstOrDefault(row => _filters.All(f => f(row)));
+
+                if (match == null) return null;
+                if (_selectedColumns != null && _selectedColumns.Count > 0)
                 {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)))
-                    {
-                        if (_selectedColumns != null && _selectedColumns.Count > 0)
-                        {
-                            return row.Where(kvp => _selectedColumns.Contains(kvp.Key))
-                                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-                        }
-                        return row;
-                    }
+                    return match.Where(kvp => _selectedColumns.Contains(kvp.Key))
+                        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                 }
-                return null;
+                return match;
             }
 
             public double Sum(string column)
             {
-                double sum = 0;
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)) && row.TryGetValue(column, out var value))
-                    {
-                        sum += Convert.ToDouble(value);
-                    }
-                }
-                return sum;
+                return Enumerable.Range(0, _source.RowCount)
+                    .Select(i => _source.GetRow(i))
+                    .Where(row => _filters.All(f => f(row)) && row.ContainsKey(column))
+                    .Sum(row => Convert.ToDouble(row[column]));
             }
 
             public double Average(string column)
             {
-                double sum = 0;
-                int count = 0;
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)) && row.TryGetValue(column, out var value))
-                    {
-                        sum += Convert.ToDouble(value);
-                        count++;
-                    }
-                }
-                return count > 0 ? sum / count : 0;
+                var values = Enumerable.Range(0, _source.RowCount)
+                    .Select(i => _source.GetRow(i))
+                    .Where(row => _filters.All(f => f(row)) && row.ContainsKey(column))
+                    .Select(row => Convert.ToDouble(row[column]));
+                return values.Any() ? values.Average() : 0;
             }
 
             public double Max(string column)
             {
-                double max = double.MinValue;
-                bool found = false;
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)) && row.TryGetValue(column, out var value))
-                    {
-                        var val = Convert.ToDouble(value);
-                        if (!found || val > max)
-                        {
-                            max = val;
-                            found = true;
-                        }
-                    }
-                }
-                return found ? max : 0;
+                var values = Enumerable.Range(0, _source.RowCount)
+                    .Select(i => _source.GetRow(i))
+                    .Where(row => _filters.All(f => f(row)) && row.ContainsKey(column))
+                    .Select(row => Convert.ToDouble(row[column]));
+                return values.Any() ? values.Max() : 0;
             }
 
             public double Min(string column)
             {
-                double min = double.MaxValue;
-                bool found = false;
-                for (int i = 0; i < _source.RowCount; i++)
-                {
-                    var row = _source.GetRow(i);
-                    if (_filters.All(f => f(row)) && row.TryGetValue(column, out var value))
-                    {
-                        var val = Convert.ToDouble(value);
-                        if (!found || val < min)
-                        {
-                            min = val;
-                            found = true;
-                        }
-                    }
-                }
-                return found ? min : 0;
+                var values = Enumerable.Range(0, _source.RowCount)
+                    .Select(i => _source.GetRow(i))
+                    .Where(row => _filters.All(f => f(row)) && row.ContainsKey(column))
+                    .Select(row => Convert.ToDouble(row[column]));
+                return values.Any() ? values.Min() : 0;
             }
         }
     }

--- a/Runtime/Tabular/TabularData.cs
+++ b/Runtime/Tabular/TabularData.cs
@@ -79,6 +79,7 @@ namespace AroAro.DataCore.Tabular
             _rowCount = data.Length;
         }
 
+        [Obsolete("Use AddNumericColumn(name, double[]) instead. Will be removed in v1.0.")]
         public void AddNumericColumn(string name, NDArray data)
         {
             if (string.IsNullOrEmpty(name))
@@ -126,17 +127,16 @@ namespace AroAro.DataCore.Tabular
 
         public bool HasColumn(string name) => _columnNames.Contains(name);
 
+        [Obsolete("Use GetNumericColumnRaw(name) instead. Will be removed in v1.0.")]
         public NDArray GetNumericColumn(string name)
         {
-            if (!_numericData.TryGetValue(name, out var data))
-                throw new KeyNotFoundException($"Numeric column '{name}' not found");
-            return np.array((double[])data.Clone());
+            return np.array(GetNumericColumnRaw(name));
         }
 
         /// <summary>
-        /// 获取数值列的原始 double[] 数组（避免 NDArray 转换开销）
+        /// 获取原始 double[] 数组（无克隆，无包装）
         /// </summary>
-        internal double[] GetNumericColumnRaw(string name)
+        public double[] GetNumericColumnRaw(string name)
         {
             if (!_numericData.TryGetValue(name, out var data))
                 throw new KeyNotFoundException($"Numeric column '{name}' not found");
@@ -499,8 +499,8 @@ namespace AroAro.DataCore.Tabular
         public double Std(string columnName)
         {
             var data = GetNumericColumnRaw(columnName);
-            if (data.Length == 0) return 0;
-            
+            if (data.Length < 2) return 0;
+
             double sum = 0;
             for (int i = 0; i < data.Length; i++) sum += data[i];
             var mean = sum / data.Length;
@@ -511,7 +511,7 @@ namespace AroAro.DataCore.Tabular
                 var d = data[i] - mean;
                 sumSquares += d * d;
             }
-            return Math.Sqrt(sumSquares / data.Length);
+            return Math.Sqrt(sumSquares / (data.Length - 1)); // Bessel correction
         }
 
         public int[] Where(string column, QueryOp op, object value)

--- a/Tests/AlgorithmTest.cs
+++ b/Tests/AlgorithmTest.cs
@@ -207,7 +207,7 @@ namespace AroAro.DataCore.Tests
             Assert.That(output, Is.Not.Null, "Should produce output tabular dataset");
             Assert.That(output.ColumnCount, Is.EqualTo(2), "Should preserve all columns");
 
-            var normalized = output.GetNumericColumn("values").ToArray<double>();
+            var normalized = output.GetNumericColumnRaw("values");
             Assert.That(Math.Abs(normalized[0] - 0.0), Is.LessThan(1e-10), $"Min should be 0, got {normalized[0]}");
             Assert.That(Math.Abs(normalized[4] - 1.0), Is.LessThan(1e-10), $"Max should be 1, got {normalized[4]}");
             Assert.That(Math.Abs(normalized[2] - 0.5), Is.LessThan(1e-10), $"Middle should be 0.5, got {normalized[2]}");
@@ -233,7 +233,7 @@ namespace AroAro.DataCore.Tests
             Assert.That(result.Success, Is.True, $"Should succeed: {result.Error}");
 
             var output = result.OutputDataset as ITabularDataset;
-            var values = output.GetNumericColumn("x").ToArray<double>();
+            var values = output.GetNumericColumnRaw("x");
             Assert.That(Math.Abs(values[0] - (-1.0)), Is.LessThan(1e-10), $"Min should be -1, got {values[0]}");
             Assert.That(Math.Abs(values[2] - 1.0), Is.LessThan(1e-10), $"Max should be 1, got {values[2]}");
             Assert.That(Math.Abs(values[1] - 0.0), Is.LessThan(1e-10), $"Middle should be 0, got {values[1]}");
@@ -254,8 +254,8 @@ namespace AroAro.DataCore.Tests
             Assert.That(result.Success, Is.True, $"Should succeed: {result.Error}");
 
             var output = result.OutputDataset as ITabularDataset;
-            var normalized = output.GetNumericColumn("normalize_me").ToArray<double>();
-            var untouched = output.GetNumericColumn("leave_me").ToArray<double>();
+            var normalized = output.GetNumericColumnRaw("normalize_me");
+            var untouched = output.GetNumericColumnRaw("leave_me");
 
             Assert.That(Math.Abs(normalized[0] - 0.0), Is.LessThan(1e-10), "Targeted column should be normalized");
             Assert.That(Math.Abs(untouched[0] - 5.0), Is.LessThan(1e-10), $"Non-targeted column should be unchanged, got {untouched[0]}");
@@ -272,7 +272,7 @@ namespace AroAro.DataCore.Tests
             Assert.That(result.Success, Is.True, $"Should succeed: {result.Error}");
 
             var output = result.OutputDataset as ITabularDataset;
-            var values = output.GetNumericColumn("flat").ToArray<double>();
+            var values = output.GetNumericColumnRaw("flat");
             Assert.That(Math.Abs(values[0] - 0.0), Is.LessThan(1e-10), "Constant value should map to rangeMin");
         }
 

--- a/Tests/DataFrameIntegrationTest.cs
+++ b/Tests/DataFrameIntegrationTest.cs
@@ -121,7 +121,7 @@ namespace AroAro.DataCore.Tests
                 var session = sessionManager.CreateSession("ConversionTest");
 
                 var tabular = session.CreateDataset("TabularSource", DataSetKind.Tabular) as Tabular.TabularData;
-                tabular.AddNumericColumn("x", NumSharp.np.array(new double[] { 1, 2, 3 }));
+                tabular.AddNumericColumn("x", new double[] { 1, 2, 3 });
                 tabular.AddStringColumn("s", new string[] { "a", "b", "c" });
 
                 var df = session.ConvertToDataFrame("TabularSource");

--- a/Tests/LiteDbTabularTest.cs
+++ b/Tests/LiteDbTabularTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
-using NumSharp;
 using UnityEngine;
 
 namespace AroAro.DataCore.Tests
@@ -39,9 +38,9 @@ namespace AroAro.DataCore.Tests
             Assert.That(table.HasColumn("score"), Is.True, "Should have 'score' column");
             Assert.That(table.HasColumn("name"), Is.True, "Should have 'name' column");
 
-            var scores = table.GetNumericColumn("score");
-            Assert.That(scores.size, Is.EqualTo(3), "Score array size should be 3");
-            Assert.That(Math.Abs(scores.GetDouble(0) - 100), Is.LessThan(0.001), "First score should be 100");
+            var scores = table.GetNumericColumnRaw("score");
+            Assert.That(scores.Length, Is.EqualTo(3), "Score array size should be 3");
+            Assert.That(Math.Abs(scores[0] - 100), Is.LessThan(0.001), "First score should be 100");
 
             var names = table.GetStringColumn("name");
             Assert.That(names.Length, Is.EqualTo(3), "Name array length should be 3");
@@ -66,8 +65,7 @@ namespace AroAro.DataCore.Tests
             using var store = DataStoreFactory.CreateLiteDb(dbPath);
             var table = store.CreateTabular("column-test");
 
-            var arr = np.array(new double[] { 1.5, 2.5, 3.5, 4.5 });
-            table.AddNumericColumn("values", arr);
+            table.AddNumericColumn("values", new double[] { 1.5, 2.5, 3.5, 4.5 });
 
             Assert.That(table.RowCount, Is.EqualTo(4), "Should have 4 rows");
             Assert.That(table.GetColumnType("values"), Is.EqualTo(ColumnType.Numeric), "Should be numeric type");
@@ -185,8 +183,8 @@ Dave,28,85.0";
             Assert.That(table.RowCount, Is.EqualTo(4), "Should have 4 rows");
             Assert.That(table.ColumnCount, Is.EqualTo(3), "Should have 3 columns");
 
-            var ages = table.GetNumericColumn("Age");
-            Assert.That(Math.Abs(ages.GetDouble(0) - 30), Is.LessThan(0.001), "First age should be 30");
+            var ages = table.GetNumericColumnRaw("Age");
+            Assert.That(Math.Abs(ages[0] - 30), Is.LessThan(0.001), "First age should be 30");
 
             var exported = table.ExportToCsv();
             Assert.That(exported.Contains("Alice"), Is.True, "Export should contain Alice");


### PR DESCRIPTION
Closes #162

## Phase 1: 移除 NumSharp 运行时依赖

### 接口 (ITabularDataset)
- 新增 `GetNumericColumnRaw(string)` → 直接返回 `double[]`（无克隆、无 NDArray 包装）
- `AddNumericColumn(string, NDArray)` 标记 `[Obsolete]`
- `GetNumericColumn(string)` 标记 `[Obsolete]`

### 实现层
- **TabularData** / **LiteDbTabularDataset**: NDArray 重载内部转调 `double[]` 版本
- **DataFrameAdapter** / **DataFrameConverter**: `np.array()` → 直接 `double[]`
- **MinMaxNormalizeAlgorithm**: `GetNumericColumn().ToArray<double>()` → `GetNumericColumnRaw()`
- **CaliforniaHousingDataset**: `np.array/min/max/mean` → LINQ `.Min()/.Max()/.Average()`
- 示例代码、自测代码全部更新

### 统计修复
- `Std` 改用 Bessel 校正（n-1）

### 测试
- 所有测试更新为 `GetNumericColumnRaw`
- Defensive copy 测试保留 NDArray 版本验证向后兼容

---

## Phase 2: 统一运算空间 — LINQ 替换手写 for 循环

### TabularData
- 统计方法 (Sum/Average/Min/Max/Std): `for` 循环 → LINQ `.Sum()/.Average()/.Min()/.Max()`
- `Where`: 手写循环 → `Enumerable.Range` + `MatchesNumericOp`/`MatchesStringOp` 辅助方法
- `ExportToCsv`: `StringBuilder` + 双重循环 → `Enumerable.Range` + `Select` 投影
- `GetRows`: `yield return` 循环 → `Enumerable.Range` + `Select`

### InMemoryTabularQuery
- `ToRowIndices`: 手写循环 → LINQ `.Where().ToArray()`
- `Any`: 手写循环 → LINQ `.Any()`
- `FirstOrDefault`: 手写循环 → LINQ `.FirstOrDefault()`
- 聚合方法 (Sum/Average/Max/Min): 手写循环 → LINQ `.Sum()/.Average()/.Max()/.Min()`

### LiteDbTabularDataset
- 统计方法: 手写 `for` 循环 → LINQ `.Sum()/.Average()/.Min()/.Max()`

### 收益
- 代码量减少 ~120 行（211 删除 / 90 新增）
- 统一使用声明式 LINQ 风格，可读性更好
- 公共 API 完全不变